### PR TITLE
refactor: Type ordering

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -155,8 +155,8 @@ export class RequestClient<Schema extends RequestDefinitions> {
    * @returns A promise resolving to `[error, data]` where `data` is the typed response.
    */
   async get<Endpoint extends GetEndpoint<Schema>>(
-    ...args: GetArgs<Endpoint & string, Schema>
-  ): SafeWrapAsync<Error, GetReturn<Endpoint, Schema>> {
+    ...args: GetArgs<Schema, Endpoint & string>
+  ): SafeWrapAsync<Error, GetReturn<Schema, Endpoint>> {
     const [endpoint, params, opts = {}] = args;
     const schemas = this.#endpoints[endpoint]?.get;
     if (!schemas) {
@@ -212,7 +212,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       return [new Error('error doing request in get', { cause: errReq }), null];
     }
 
-    const [errResponse, result] = await getResponseData<GetReturn<Endpoint, Schema>>(response);
+    const [errResponse, result] = await getResponseData<GetReturn<Schema, Endpoint>>(response);
     if (errResponse) {
       return [new Error('error getting response in get', { cause: errResponse }), null];
     }
@@ -241,8 +241,8 @@ export class RequestClient<Schema extends RequestDefinitions> {
    * @returns A promise resolving to `[error, data]` where `data` is the typed response.
    */
   async post<Endpoint extends PostEndpoint<Schema>>(
-    ...args: PostArgs<Endpoint & string, Schema>
-  ): SafeWrapAsync<Error, PostReturn<Endpoint, Schema>> {
+    ...args: PostArgs<Schema, Endpoint & string>
+  ): SafeWrapAsync<Error, PostReturn<Schema, Endpoint>> {
     const [endpoint, params, rawData, opts = {}] = args;
     let data = rawData;
     const schemas = this.#endpoints[endpoint]?.post;
@@ -281,7 +281,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       return [new Error('error doing request in post', { cause: errReq }), null];
     }
 
-    const [errResponse, result] = await getResponseData<PostReturn<Endpoint, Schema>>(response);
+    const [errResponse, result] = await getResponseData<PostReturn<Schema, Endpoint>>(response);
     if (errResponse) {
       return [new Error('error getting response in post', { cause: errResponse }), null];
     }
@@ -310,8 +310,8 @@ export class RequestClient<Schema extends RequestDefinitions> {
    * @returns A promise resolving to `[error, data]` where `data` is the typed response.
    */
   async put<Endpoint extends PutEndpoint<Schema>>(
-    ...args: PutArgs<Endpoint & string, Schema>
-  ): SafeWrapAsync<Error, PutReturn<Endpoint, Schema>> {
+    ...args: PutArgs<Schema, Endpoint & string>
+  ): SafeWrapAsync<Error, PutReturn<Schema, Endpoint>> {
     const [endpoint, params, rawData, opts = {}] = args;
     let data = rawData;
     const schemas = this.#endpoints[endpoint]?.put;
@@ -349,7 +349,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       return [new Error('error doing request in put', { cause: errReq }), null];
     }
 
-    const [errResponse, result] = await getResponseData<PutReturn<Endpoint, Schema>>(response);
+    const [errResponse, result] = await getResponseData<PutReturn<Schema, Endpoint>>(response);
     if (errResponse) {
       return [new Error('error getting response in put', { cause: errResponse }), null];
     }
@@ -378,8 +378,8 @@ export class RequestClient<Schema extends RequestDefinitions> {
    * @returns A promise resolving to `[error, data]` where `data` is the typed response.
    */
   async patch<Endpoint extends PatchEndpoint<Schema>>(
-    ...args: PatchArgs<Endpoint & string, Schema>
-  ): SafeWrapAsync<Error, PatchReturn<Endpoint, Schema>> {
+    ...args: PatchArgs<Schema, Endpoint & string>
+  ): SafeWrapAsync<Error, PatchReturn<Schema, Endpoint>> {
     const [endpoint, params, rawData, opts = {}] = args;
     let data = rawData;
     const schemas = this.#endpoints[endpoint]?.patch;
@@ -415,7 +415,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       return [new Error('error doing request in patch', { cause: errReq }), null];
     }
 
-    const [errResponse, result] = await getResponseData<PatchReturn<Endpoint, Schema>>(response);
+    const [errResponse, result] = await getResponseData<PatchReturn<Schema, Endpoint>>(response);
     if (errResponse) {
       return [new Error('error getting response in patch', { cause: errResponse }), null];
     }
@@ -443,8 +443,8 @@ export class RequestClient<Schema extends RequestDefinitions> {
    * @returns A promise resolving to `[error, data]` where `data` is the typed response.
    */
   async delete<Endpoint extends DeleteEndpoint<Schema>>(
-    ...args: DeleteArgs<Endpoint & string, Schema>
-  ): SafeWrapAsync<Error, DeleteReturn<Endpoint, Schema>> {
+    ...args: DeleteArgs<Schema, Endpoint & string>
+  ): SafeWrapAsync<Error, DeleteReturn<Schema, Endpoint>> {
     const [endpoint, params, opts = {}] = args;
     const schemas = this.#endpoints[endpoint]?.delete;
     if (!schemas) {
@@ -469,7 +469,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       return [new Error('error doing request in delete', { cause: errReq }), null];
     }
 
-    const [errResponse, result] = await getResponseData<DeleteReturn<Endpoint, Schema>>(response);
+    const [errResponse, result] = await getResponseData<DeleteReturn<Schema, Endpoint>>(response);
     if (errResponse) {
       return [new Error('error getting response in delete', { cause: errResponse }), null];
     }
@@ -497,7 +497,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
    * @returns A promise resolving to `[error, blob]`.
    */
   async download<Endpoint extends DownloadEndpoint<Schema>>(
-    ...args: DownloadArgs<Endpoint & string, Schema>
+    ...args: DownloadArgs<Schema, Endpoint & string>
   ): SafeWrapAsync<Error, Blob> {
     const [endpoint, params, opts = {}] = args;
     const schemas = this.#endpoints[endpoint]?.download;
@@ -542,7 +542,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
    * @returns A tuple `[error, url]` where `url` is the resolved absolute URL.
    */
   async url<Endpoint extends UrlEndpoint<Schema>>(
-    ...args: UrlArgs<Endpoint & string, Schema>
+    ...args: UrlArgs<Schema, Endpoint & string>
   ): SafeWrapAsync<Error, string> {
     const [endpoint, params] = args;
     const schemas = this.#endpoints[endpoint]?.url;
@@ -592,7 +592,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
    *          that closes the SSE stream.
    */
   async sse<Endpoint extends SSEEndpoint<Schema>>(
-    ...args: SSEArgs<Endpoint & string, Schema>
+    ...args: SSEArgs<Schema, Endpoint & string>
   ): SafeWrapAsync<Error, SSEReturn> {
     const [endpoint, params, handler, options] = args;
     const opts = { withCredentials: this.#credentials !== 'omit', ...options };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -181,9 +181,9 @@ type PathKeys<
 
 /** Combined params object (path + query) expected by client methods. */
 export type Params<
+  Schema extends RequestDefinitions,
   Endpoint extends keyof RequestDefinitions & string,
   Method extends HttpMethod & keyof RequestDefinitions[Endpoint],
-  Schema extends RequestDefinitions,
 > = EmptyishObject<
   // drop from ParsePathParams any keys that are handled by $path
   Omit<ParsePathParams<Endpoint>, PathKeys<Schema, Endpoint, Method>> &
@@ -211,28 +211,28 @@ export type UrlEndpoint<Schema extends RequestDefinitions> = EndpointsWithMethod
 /**
  * Typed parameters for get function call parameters
  */
-export type SSEArgs<Endpoint extends SSEEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type SSEArgs<Schema extends RequestDefinitions, Endpoint extends SSEEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'sse', Schema>,
-  handler: (data: SafeWrap<Error, SSEDataReturn<Endpoint, Schema>>) => void,
+  params: Params<Schema, Endpoint, 'sse'>,
+  handler: (data: SafeWrap<Error, SSEDataReturn<Schema, Endpoint>>) => void,
   options?: SSEClientSourceInit & { validate?: boolean; timeout?: number },
 ];
 
 /**
  * Typed parameters for get function call parameters
  */
-export type GetArgs<Endpoint extends GetEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type GetArgs<Schema extends RequestDefinitions, Endpoint extends GetEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'get', Schema>,
+  params: Params<Schema, Endpoint, 'get'>,
   options?: HttpRequestOptions,
 ];
 
 /**
  * Typed parameters for post function call parameters
  */
-export type PostArgs<Endpoint extends PostEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type PostArgs<Schema extends RequestDefinitions, Endpoint extends PostEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'post', Schema>,
+  params: Params<Schema, Endpoint, 'post'>,
   data: RequestType<Schema, Endpoint, 'post'>,
   options?: Omit<HttpRequestOptions, 'cacheRequest' | 'cacheTimeToLive'>,
 ];
@@ -240,9 +240,9 @@ export type PostArgs<Endpoint extends PostEndpoint<Schema> & string, Schema exte
 /**
  * Typed parameters for put function call parameters
  */
-export type PutArgs<Endpoint extends PutEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type PutArgs<Schema extends RequestDefinitions, Endpoint extends PutEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'put', Schema>,
+  params: Params<Schema, Endpoint, 'put'>,
   data: RequestType<Schema, Endpoint, 'put'>,
   options?: Omit<HttpRequestOptions, 'cacheRequest' | 'cacheTimeToLive'>,
 ];
@@ -250,9 +250,9 @@ export type PutArgs<Endpoint extends PutEndpoint<Schema> & string, Schema extend
 /**
  * Typed parameters for patch function call parameters
  */
-export type PatchArgs<Endpoint extends PatchEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type PatchArgs<Schema extends RequestDefinitions, Endpoint extends PatchEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'patch', Schema>,
+  params: Params<Schema, Endpoint, 'patch'>,
   data: RequestType<Schema, Endpoint, 'patch'>,
   options?: Omit<HttpRequestOptions, 'cacheRequest' | 'cacheTimeToLive'>,
 ];
@@ -260,66 +260,66 @@ export type PatchArgs<Endpoint extends PatchEndpoint<Schema> & string, Schema ex
 /**
  * Typed parameters for delete function call parameters
  */
-export type DeleteArgs<Endpoint extends DeleteEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type DeleteArgs<Schema extends RequestDefinitions, Endpoint extends DeleteEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'delete', Schema>,
+  params: Params<Schema, Endpoint, 'delete'>,
   options?: Omit<HttpRequestOptions, 'cacheRequest' | 'cacheTimeToLive'>,
 ];
 
 /**
  * Typed parameters for download function call parameters
  */
-export type DownloadArgs<Endpoint extends DownloadEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type DownloadArgs<Schema extends RequestDefinitions, Endpoint extends DownloadEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'download', Schema>,
+  params: Params<Schema, Endpoint, 'download'>,
   options?: HttpRequestOptions,
 ];
 
 /**
  * Typed parameters for url function call parameters
  */
-export type UrlArgs<Endpoint extends UrlEndpoint<Schema> & string, Schema extends RequestDefinitions> = [
+export type UrlArgs<Schema extends RequestDefinitions, Endpoint extends UrlEndpoint<Schema> & string> = [
   endpoint: Endpoint,
-  params: Params<Endpoint, 'url', Schema>,
+  params: Params<Schema, Endpoint, 'url'>,
 ];
 
 /** Typed return-type for get function */
-export type GetReturn<T extends GetEndpoint<Schema>, Schema extends RequestDefinitions> = ResponseType<
+export type GetReturn<Schema extends RequestDefinitions, T extends GetEndpoint<Schema>> = ResponseType<
   Schema,
   T,
   'get'
 >;
 
 /** Typed return-type for post function */
-export type PostReturn<T extends PostEndpoint<Schema>, Schema extends RequestDefinitions> = ResponseType<
+export type PostReturn<Schema extends RequestDefinitions, T extends PostEndpoint<Schema>> = ResponseType<
   Schema,
   T,
   'post'
 >;
 
 /** Typed return-type for put function */
-export type PutReturn<T extends PutEndpoint<Schema>, Schema extends RequestDefinitions> = ResponseType<
+export type PutReturn<Schema extends RequestDefinitions, T extends PutEndpoint<Schema>> = ResponseType<
   Schema,
   T,
   'put'
 >;
 
 /** Typed return-type for patch function */
-export type PatchReturn<T extends PatchEndpoint<Schema>, Schema extends RequestDefinitions> = ResponseType<
+export type PatchReturn<Schema extends RequestDefinitions, T extends PatchEndpoint<Schema>> = ResponseType<
   Schema,
   T,
   'patch'
 >;
 
 /** Typed return-type for delete function */
-export type DeleteReturn<T extends DeleteEndpoint<Schema>, Schema extends RequestDefinitions> = ResponseType<
+export type DeleteReturn<Schema extends RequestDefinitions, T extends DeleteEndpoint<Schema>> = ResponseType<
   Schema,
   T,
   'delete'
 >;
 
 /** Typed return-type for URL builder */
-export type UrlReturn<T extends UrlEndpoint<Schema>, Schema extends RequestDefinitions> = ResponseType<
+export type UrlReturn<Schema extends RequestDefinitions, T extends UrlEndpoint<Schema>> = ResponseType<
   Schema,
   T,
   'url'
@@ -328,6 +328,6 @@ export type UrlReturn<T extends UrlEndpoint<Schema>, Schema extends RequestDefin
 /**
  * Typed return-type for get function
  */
-type SSEDataReturn<T extends SSEEndpoint<Schema>, Schema extends RequestDefinitions> = ResponseType<Schema, T, 'sse'>;
+type SSEDataReturn<Schema extends RequestDefinitions, T extends SSEEndpoint<Schema>> = ResponseType<Schema, T, 'sse'>;
 
 export type SSEReturn = () => void;

--- a/src/utils/constructUrl.ts
+++ b/src/utils/constructUrl.ts
@@ -7,12 +7,12 @@ import type { SafeWrapAsync } from './wrap';
  * Handles strict validation of $path and $search if enabled.
  */
 export async function constructUrl<
-  Endpoint extends EndpointsWithMethod<Method, Schema> & string,
   Method extends HttpMethod,
   Schema extends RequestDefinitions,
+  Endpoint extends EndpointsWithMethod<Method, Schema> & string,
 >(
   path: Endpoint,
-  params: Params<Endpoint, Method, Schema>,
+  params: Params<Schema, Endpoint, Method>,
   schema: Schema[Endpoint][Method],
   validation?: boolean,
 ): SafeWrapAsync<Error, string> {


### PR DESCRIPTION
Order types for schema/method reference more semantically correct (e.g. Schema before Endpoint that references Schema, etc)
