### PR TITLE
fix: Type narrowing options

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -60,7 +60,7 @@ export interface RequestClientProps<Schema extends RequestDefinitions> {
   /** Optional cache configuration for GET requests. {@link CacheClientOptions} */
   cacheOpts?: CacheClientOptions;
   /** Optional fetch configuration, including request-level defaults (timeouts, retry). */
-  fetchOpts?: Omit<Options, 'signal'>;
+  fetchOpts?: Omit<Options, 'signal' | 'cacheRequest' | 'cacheTimeToLive'>;
   /**
    * Whether to log debug information to the console.
    * @default false

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -880,6 +880,6 @@ export class RequestClient<Schema extends RequestDefinitions> {
       return;
     }
 
-    console.debug(args);
+    console.debug(...args);
   }
 }

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -146,10 +146,10 @@ export type Options = Pick<FetchOptions, 'credentials' | 'headers' | 'mode' | 's
  * - `fetchOpts`: default fetch/request options (headers, credentials, etc.).
  * - `cacheOpts`: cache defaults for GET requests.
  */
-export type Config = {
-  fetchOpts?: Omit<Options, 'signal'>;
+export interface Config {
+  fetchOpts?: Omit<Options, 'signal' | 'cacheRequest' | 'cacheTimeToLive'>;
   cacheOpts?: CacheClientOptions;
-};
+}
 
 /** Contract for HTTP client implementations used by RequestClient. */
 export interface FetchClientProviderDefinition {


### PR DESCRIPTION
Omit cacheRequest + cacheTimeToLive for config and instantiations (as they don't do anything)
