### PR TITLE
feat: 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ const [err, close] = await client.sse(
     console.log('sse message', data);
   },
   // The SSE client also inherits credentials adding from the fetchOpts
-  // as long as it is not 'omit'
+  // as long as it is not 'omit', so usually this will end up sending withCredentials: true
   { withCredentials: true },
 );
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Typed HTTP client utilities for defining endpoints with [@standard-schema](https
   - [Client options](#client-options)
   - [Request options](#request-options)
   - [Runtime config (optional)](#runtime-config-optional)
+  - [Disposal](#disposal)
   - [Methods](#methods)
     - [GET](#get)
     - [POST](#post)
@@ -186,6 +187,16 @@ client.config({
 ```
 
 The method forwards fetch-related updates to the underlying fetch provider and cache-related updates to the cache client without recreating them, so connections and caches stay intact while defaults change.
+
+## Disposal
+
+`RequestClient` runs a small cleanup interval for the in-memory cache. For short-lived clients (scripts, tests), call `client.dispose()` to clear timers and drop cached entries. If your custom fetch provider exposes `dispose`, it will be called too (useful for cleaning up agents, sockets, etc.).
+
+```ts
+const client = new RequestClient({ /* ... */ });
+// ...use the client...
+client.dispose(); // clears cache timers/state and invokes provider dispose if present
+```
 
 ## Methods
 

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -109,6 +109,9 @@ beforeAll(async () => {
     endpoints,
     validation: true,
     sseProvider: EventSource,
+    fetchOpts: {
+      headers: new Headers([['x-type', 'e2e-global']]),
+    },
   });
 });
 
@@ -123,24 +126,42 @@ afterAll(async () => {
 
 describe('wiretyped e2e', () => {
   test('GET /ok returns data and no error', async () => {
-    const [err, data] = await client.get('/ok/{integration}', {
-      $path: { integration: 'slack' },
-      $search: { q: 'test' },
-    });
+    const [err, data] = await client.get(
+      '/ok/{integration}',
+      {
+        $path: { integration: 'slack' },
+        $search: { q: 'test' },
+      },
+      {
+        headers: new Headers([['x-client', 'e2e-scoped']]),
+      },
+    );
     expect(err).toBeNull();
     expect(data?.success).toBe(true);
   });
 
   test('caching reduces server hits (if enabled)', async () => {
     // If cache is per-request, pass options here.
-    await client.get('/ok/{integration}', {
-      $path: { integration: 'slack' },
-      $search: { q: 'test' },
-    });
-    await client.get('/ok/{integration}', {
-      $path: { integration: 'slack' },
-      $search: { q: 'test' },
-    });
+    await client.get(
+      '/ok/{integration}',
+      {
+        $path: { integration: 'slack' },
+        $search: { q: 'test' },
+      },
+      {
+        headers: new Headers([['x-client', 'e2e-scoped']]),
+      },
+    );
+    await client.get(
+      '/ok/{integration}',
+      {
+        $path: { integration: 'slack' },
+        $search: { q: 'test' },
+      },
+      {
+        headers: new Headers([['x-client', 'e2e-scoped']]),
+      },
+    );
 
     const counts = server.getCounts();
     expect(counts['GET /ok/slack']).toBeLessThanOrEqual(2);
@@ -151,6 +172,9 @@ describe('wiretyped e2e', () => {
       '/ok/{integration}',
       { $path: { integration: 'github' }, $search: { q: 'test' } },
       { test: 'yes' },
+      {
+        headers: new Headers([['x-client', 'e2e-scoped']]),
+      },
     );
 
     expect(err).toBeNull();
@@ -163,6 +187,9 @@ describe('wiretyped e2e', () => {
       '/ok/{integration}',
       { $path: { integration: 'github' }, $search: { q: 'test' } },
       { test: 'yes' },
+      {
+        headers: new Headers([['x-client', 'e2e-scoped']]),
+      },
     );
 
     expect(err).toBeNull();
@@ -175,6 +202,9 @@ describe('wiretyped e2e', () => {
       '/ok/{integration}',
       { $path: { integration: 'github' }, $search: { q: 'test' } },
       { test: 'yes' },
+      {
+        headers: new Headers([['x-client', 'e2e-scoped']]),
+      },
     );
 
     expect(err).toBeNull();
@@ -183,10 +213,16 @@ describe('wiretyped e2e', () => {
   });
 
   test('DOWNLOAD /ok returns blob payload', async () => {
-    const [err, blob] = await client.download('/ok/{integration}', {
-      $path: { integration: 'github' },
-      $search: { q: 'file' },
-    });
+    const [err, blob] = await client.download(
+      '/ok/{integration}',
+      {
+        $path: { integration: 'github' },
+        $search: { q: 'file' },
+      },
+      {
+        headers: new Headers([['x-client', 'e2e-scoped']]),
+      },
+    );
 
     expect(err).toBeNull();
     expect(blob).toBeInstanceOf(Blob);
@@ -198,7 +234,7 @@ describe('wiretyped e2e', () => {
       '/ok/{integration}',
       // @ts-expect-error
       { $path: { integration: 'not-allowed' }, $search: { q: 'bad' } },
-      { validate: false },
+      { validate: false, headers: new Headers([['x-client', 'e2e-scoped']]) },
     );
 
     expect(isHttpError(err)).toBe(true);

--- a/e2e/server.ts
+++ b/e2e/server.ts
@@ -41,6 +41,15 @@ export async function startE2EServer(endpoints: RequestDefinitions): SafeWrapAsy
         return c.notFound();
       }
 
+          const headers = c.req.header();
+    if (headers['x-client'] !== 'e2e-scoped') {
+      return c.json({ error: 'missing inlined header' }, 500);
+    }
+
+    if (headers['x-type'] !== 'e2e-global') {
+      return c.json({ error: 'missing global header' }, 500);
+    }
+
       const integration = c.req.param('integration');
       const counterPath = `/ok/${integration}`;
       incremenet(`${counterMethod} ${counterPath}`);
@@ -95,6 +104,15 @@ export async function startE2EServer(endpoints: RequestDefinitions): SafeWrapAsy
     const schemas = flakySchemas.get;
     if (!schemas) {
       return c.json({ error: 'missing schema for flaky' }, 500);
+    }
+
+        const headers = c.req.header();
+    if (headers['x-client'] !== 'e2e-scoped') {
+      return c.json({ error: 'missing inlined header' }, 500);
+    }
+
+    if (headers['x-type'] !== 'e2e-global') {
+      return c.json({ error: 'missing global header' }, 500);
     }
 
     const searchParams = c.req.query();

--- a/e2e/server.ts
+++ b/e2e/server.ts
@@ -41,14 +41,14 @@ export async function startE2EServer(endpoints: RequestDefinitions): SafeWrapAsy
         return c.notFound();
       }
 
-          const headers = c.req.header();
-    if (headers['x-client'] !== 'e2e-scoped') {
-      return c.json({ error: 'missing inlined header' }, 500);
-    }
+      const headers = c.req.header();
+      if (headers['x-client'] !== 'e2e-scoped') {
+        return c.json({ error: 'missing inlined header' }, 500);
+      }
 
-    if (headers['x-type'] !== 'e2e-global') {
-      return c.json({ error: 'missing global header' }, 500);
-    }
+      if (headers['x-type'] !== 'e2e-global') {
+        return c.json({ error: 'missing global header' }, 500);
+      }
 
       const integration = c.req.param('integration');
       const counterPath = `/ok/${integration}`;
@@ -106,7 +106,7 @@ export async function startE2EServer(endpoints: RequestDefinitions): SafeWrapAsy
       return c.json({ error: 'missing schema for flaky' }, 500);
     }
 
-        const headers = c.req.header();
+    const headers = c.req.header();
     if (headers['x-client'] !== 'e2e-scoped') {
       return c.json({ error: 'missing inlined header' }, 500);
     }

--- a/jsr.json
+++ b/jsr.json
@@ -12,5 +12,15 @@
     "browser": true,
     "bun": true
   },
-  "exclude": ["scripts/**", "**/*.test.*", "**/*.spec.*", "coverage/**", "e2e/**"]
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "**/*.test.*",
+    "**/*.spec.*",
+    "coverage/**",
+    "scripts/**",
+    "e2e/**",
+    "vitest.config.ts",
+    "vite.config.ts",
+    "tsconfig*.json"
+  ]
 }

--- a/jsr.json
+++ b/jsr.json
@@ -12,15 +12,7 @@
     "browser": true,
     "bun": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": [
-    "**/*.test.*",
-    "**/*.spec.*",
-    "coverage/**",
-    "scripts/**",
-    "e2e/**",
-    "vitest.config.ts",
-    "vite.config.ts",
-    "tsconfig*.json"
-  ]
+  "publish": {
+    "include": ["LICENSE", "README.md", "src/**/*.ts"]
+  }
 }

--- a/jsr.json
+++ b/jsr.json
@@ -12,5 +12,5 @@
     "browser": true,
     "bun": true
   },
-  "exclude": ["scripts/**", "**/*.test.*", "**/*.spec.*", "coverage/**"]
+  "exclude": ["scripts/**", "**/*.test.*", "**/*.spec.*", "coverage/**", "e2e/**"]
 }

--- a/jsr.json
+++ b/jsr.json
@@ -13,6 +13,6 @@
     "bun": true
   },
   "publish": {
-    "include": ["LICENSE", "README.md", "src/**/*.ts"]
+    "include": ["LICENSE", "README.md", "src/**/*.ts", "package.json"]
   }
 }

--- a/jsr.json
+++ b/jsr.json
@@ -13,6 +13,6 @@
     "bun": true
   },
   "publish": {
-    "include": ["LICENSE", "README.md", "src/**/*.ts", "package.json"]
+    "include": ["LICENSE", "CONTRIBUTING.md", "README.md", "src/**/*.ts", "package.json"]
   }
 }

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kasperrt/wiretyped",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "exports": {
     ".": "./src/index.ts",
     "./core": "./src/core/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiretyped",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Typed HTTP client with error-first ergonomics, caching, retries, SSE, and runtime validation powered by @standard-schema/spec.",
   "type": "module",
   "keywords": [

--- a/src/cache/client.test.ts
+++ b/src/cache/client.test.ts
@@ -258,6 +258,29 @@ describe('CacheClient', () => {
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
+  it('dispose clears cleanup interval and cache state', async () => {
+    const client = new CacheClient({ ttl: 1_000, cleanupInterval: 500 });
+
+    const fetchFn = vi.fn().mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+    // @ts-expect-error
+    const [err1, res1] = await client.get('key', () => fetchFn().then((d) => [null, d] as const));
+    expect(err1).toBeNull();
+    expect(res1).toBe('first');
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    client.dispose();
+
+    expect(vi.getTimerCount()).toBe(0);
+
+    // After dispose, cache should be cleared and resolver should run again
+    // @ts-expect-error
+    const [err2, res2] = await client.get('key', () => fetchFn().then((d) => [null, d] as const));
+    expect(err2).toBeNull();
+    expect(res2).toBe('second');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
   it('allows updating ttl and cleanupInterval via config', async () => {
     const client = new CacheClient({ ttl: 500, cleanupInterval: 30_000 });
 

--- a/src/cache/client.ts
+++ b/src/cache/client.ts
@@ -70,6 +70,17 @@ export class CacheClient {
   }
 
   /**
+   * Disposes the cache client by clearing timers and cached entries.
+   * Useful for short-lived clients to avoid leaking intervals.
+   */
+  public dispose() {
+    clearInterval(this.#intervalId);
+    this.#intervalId = undefined;
+    this.#cache = {};
+    this.#pending = {};
+  }
+
+  /**
    * Add item to cache by provided key
    * @param {string} key - cache key
    * @param {Object} data - cache data

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -510,6 +510,44 @@ describe('RequestClient', () => {
       expect(getSpy).toHaveBeenCalledTimes(1);
     });
 
+    test('Skips retries for non-listed status when ignoreStatusCodes is set', async () => {
+      const mockGetEndpoints = {
+        '/api/my-endpoint': {
+          get: { response: z.object({ data: z.string() }) },
+        },
+      } satisfies RequestDefinitions;
+
+      const httpResponse = {
+        ok: false,
+        status: 418,
+        json: () => ({ message: 'teapot' }),
+        text: () => '{ "message": "teapot" }',
+        headers: { get: () => 'application/json' },
+      };
+
+      const getSpy = vi
+        .spyOn(MOCK_FETCH_PROVIDER.prototype, 'get')
+        .mockImplementation(async () => asyncOk(httpResponse));
+
+      const requestClient: RequestClient<typeof mockGetEndpoints> = new RequestClient({
+        fetchProvider: MOCK_FETCH_PROVIDER,
+        sseProvider: MOCK_SSE_PROVIDER,
+        baseUrl: 'https://api.example.com/base',
+        hostname: 'https://api.example.com',
+        fetchOpts: { retry: { limit: 3, timeout: 1, ignoreStatusCodes: [429] }, timeout: false },
+        endpoints: mockGetEndpoints,
+        validation: true,
+      });
+
+      const promise = requestClient.get('/api/my-endpoint', null);
+      const [err, res] = await promise;
+
+      expect(res).toBeNull();
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).cause).toBeInstanceOf(HTTPError);
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
     test('Retries when status is in retryCodes and ignoreStatusCodes is empty', async () => {
       const mockGetEndpoints = {
         '/api/my-endpoint': {
@@ -1728,7 +1766,10 @@ describe('RequestClient', () => {
       expect(postSpy).toHaveBeenCalledOnce();
       expect(postSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toBeNull();
     });
@@ -1757,7 +1798,10 @@ describe('RequestClient', () => {
       expect(postSpy).toHaveBeenCalledOnce();
       expect(postSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toBeNull();
     });
@@ -1783,7 +1827,10 @@ describe('RequestClient', () => {
       expect(postSpy).toHaveBeenCalledOnce();
       expect(postSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'POST returned from mock provider no params',
@@ -1809,7 +1856,10 @@ describe('RequestClient', () => {
       expect(postSpy).toHaveBeenCalledOnce();
       expect(postSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'POST returned from mock provider no params',
@@ -1848,7 +1898,10 @@ describe('RequestClient', () => {
       expect(postSpy).toHaveBeenCalledOnce();
       expect(postSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'POST returned from mock provider no params',
@@ -1878,7 +1931,10 @@ describe('RequestClient', () => {
       expect(postSpy).toHaveBeenCalledOnce();
       expect(postSpy).toHaveBeenCalledWith(
         'api/my-endpoint/hey',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'POST returned from mock provider with params',
@@ -1903,7 +1959,10 @@ describe('RequestClient', () => {
       expect(postSpy).toHaveBeenCalledOnce();
       expect(postSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(err).toBeInstanceOf(Error);
       expect(err).toStrictEqual(
@@ -2042,7 +2101,10 @@ describe('RequestClient', () => {
       expect(putSpy).toHaveBeenCalledOnce();
       expect(putSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toBeNull();
     });
@@ -2071,7 +2133,10 @@ describe('RequestClient', () => {
       expect(putSpy).toHaveBeenCalledOnce();
       expect(putSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toBeNull();
     });
@@ -2095,7 +2160,7 @@ describe('RequestClient', () => {
       expect(putSpy).toHaveBeenCalledOnce();
       expect(putSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Pooh' }) }),
+        expect.objectContaining({ headers: new Headers(DEFAULT_HEADERS_SEND), body: JSON.stringify({ name: 'Pooh' }) }),
       );
       expect(res).toStrictEqual({
         data: 'PUT returned from mock provider no params',
@@ -2121,7 +2186,10 @@ describe('RequestClient', () => {
       expect(putSpy).toHaveBeenCalledOnce();
       expect(putSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'POST returned from mock provider no params',
@@ -2160,7 +2228,10 @@ describe('RequestClient', () => {
       expect(putSpy).toHaveBeenCalledOnce();
       expect(putSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'POST returned from mock provider no params',
@@ -2190,7 +2261,7 @@ describe('RequestClient', () => {
       expect(putSpy).toHaveBeenCalledOnce();
       expect(putSpy).toHaveBeenCalledWith(
         'api/my-endpoint/hey',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Pooh' }) }),
+        expect.objectContaining({ headers: new Headers(DEFAULT_HEADERS_SEND), body: JSON.stringify({ name: 'Pooh' }) }),
       );
       expect(res).toStrictEqual({
         data: 'PUT returned from mock provider with params',
@@ -2215,7 +2286,7 @@ describe('RequestClient', () => {
       expect(putSpy).toHaveBeenCalledOnce();
       expect(putSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Pooh' }) }),
+        expect.objectContaining({ headers: new Headers(DEFAULT_HEADERS_SEND), body: JSON.stringify({ name: 'Pooh' }) }),
       );
       expect(err).toBeInstanceOf(Error);
       expect(err).toStrictEqual(
@@ -2349,7 +2420,10 @@ describe('RequestClient', () => {
       expect(patchSpy).toHaveBeenCalledOnce();
       expect(patchSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toBeNull();
     });
@@ -2378,7 +2452,10 @@ describe('RequestClient', () => {
       expect(patchSpy).toHaveBeenCalledOnce();
       expect(patchSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Brother' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Brother' }),
+        }),
       );
       expect(res).toBeNull();
     });
@@ -2404,7 +2481,10 @@ describe('RequestClient', () => {
       expect(patchSpy).toHaveBeenCalledOnce();
       expect(patchSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Little Foot' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Little Foot' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'PATCH returned from mock provider no params',
@@ -2435,7 +2515,10 @@ describe('RequestClient', () => {
       expect(patchSpy).toHaveBeenCalledOnce();
       expect(patchSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Little Foot' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Little Foot' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'PATCH returned from mock provider no params',
@@ -2474,7 +2557,10 @@ describe('RequestClient', () => {
       expect(patchSpy).toHaveBeenCalledOnce();
       expect(patchSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Little Foot' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Little Foot' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'PATCH returned from mock provider no params',
@@ -2504,7 +2590,10 @@ describe('RequestClient', () => {
       expect(patchSpy).toHaveBeenCalledOnce();
       expect(patchSpy).toHaveBeenCalledWith(
         'api/my-endpoint/hey',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Little Foot' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Little Foot' }),
+        }),
       );
       expect(res).toStrictEqual({
         data: 'PATCH returned from mock provider with params',
@@ -2529,7 +2618,10 @@ describe('RequestClient', () => {
       expect(patchSpy).toHaveBeenCalledOnce();
       expect(patchSpy).toHaveBeenCalledWith(
         'api/my-endpoint',
-        expect.objectContaining({ headers: DEFAULT_HEADERS_SEND, body: JSON.stringify({ name: 'Little Foot' }) }),
+        expect.objectContaining({
+          headers: new Headers(DEFAULT_HEADERS_SEND),
+          body: JSON.stringify({ name: 'Little Foot' }),
+        }),
       );
       expect(err).toBeInstanceOf(Error);
       expect(err).toStrictEqual(
@@ -2860,6 +2952,23 @@ describe('RequestClient', () => {
       const handler = vi.fn();
 
       const [err, close] = await requestClient.sse('/api/my-sse', null, handler);
+
+      expect(err).toBeNull();
+      expect(MOCK_SSE_PROVIDER).toHaveBeenCalledOnce();
+
+      const instance = MOCK_SSE_PROVIDER.mock.instances[0];
+
+      expect(instance.url).toBe('https://api.example.com/base/api/my-sse');
+      expect(instance.withCredentials).toBe(false);
+
+      close?.();
+      expect(instance.close).toHaveBeenCalled();
+    });
+
+    test('Constructs SSE connection and returns close function, with credentials', async () => {
+      const handler = vi.fn();
+
+      const [err, close] = await requestClient.sse('/api/my-sse', null, handler, { withCredentials: true });
 
       expect(err).toBeNull();
       expect(MOCK_SSE_PROVIDER).toHaveBeenCalledOnce();

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -3488,7 +3488,6 @@ describe('RequestClient', () => {
       vi.useRealTimers();
     });
 
-
     test('sse() returns error when new is run', async () => {
       vi.useFakeTimers();
       const LOCAL_SSE_PROVIDER = vi.fn(function (

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -217,6 +217,15 @@ export class RequestClient<Schema extends RequestDefinitions> {
   }
 
   /**
+   * Disposes resources held by this client (cache timers, pending cache entries).
+   * Invoke when tearing down short-lived clients to avoid leaking intervals.
+   */
+  dispose() {
+    this.#cacheClient.dispose();
+    this.#fetchClient.dispose?.();
+  }
+
+  /**
    * Performs a typed GET request against a configured endpoint.
    *
    * - Builds the URL from endpoint definitions and params.

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -71,7 +71,7 @@ export interface RequestClientProps<Schema extends RequestDefinitions> {
    *
    * When `true`, request and response payloads are validated with the
    * configured schemas by default. Per-request options can override this.
-   * @default false
+   * @default true
    */
   validation?: boolean;
   /**
@@ -342,7 +342,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       {
         ...opts,
         body: JSON.stringify(data),
-        headers: { 'Content-Type': 'application/json', ...opts.headers },
+        headers: mergeHeaderOptions({ 'Content-Type': 'application/json' }, opts.headers),
       },
       getResponseData,
     );
@@ -409,7 +409,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       {
         ...opts,
         body: JSON.stringify(data),
-        headers: { 'Content-Type': 'application/json', ...opts.headers },
+        headers: mergeHeaderOptions({ 'Content-Type': 'application/json' }, opts.headers),
       },
       getResponseData,
     );
@@ -476,7 +476,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       {
         ...opts,
         body: JSON.stringify(data),
-        headers: { 'Content-Type': 'application/json', ...opts.headers },
+        headers: mergeHeaderOptions({ 'Content-Type': 'application/json' }, opts.headers),
       },
       getResponseData,
     );
@@ -644,7 +644,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
     ...args: SSEArgs<Schema, Endpoint & string>
   ): SafeWrapAsync<Error, SSEReturn> {
     const [endpoint, params, handler, { validate, ...options } = {}] = args;
-    const opts = { withCredentials: this.#credentials !== 'omit', ...options };
+    const opts = { withCredentials: options?.withCredentials ?? this.#credentials === 'include', ...options };
 
     this.#log(`SSE OPTIONS: ${JSON.stringify(opts, null, 4)}`);
 
@@ -840,7 +840,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
           return true;
         }
 
-        if (retryStatusCodes.includes(httpError.response.status) || retryIgnoreStatusCodes.length > 0) {
+        if (retryStatusCodes.includes(httpError.response.status)) {
           return false;
         }
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -679,11 +679,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       let connection: SSEClientProviderDefinition | null = null;
 
       const closeConnection = () => {
-        if (!connection) {
-          return;
-        }
-
-        if (connection.readyState === connection.CLOSED) {
+        if (!connection || connection.readyState === connection.CLOSED) {
           return;
         }
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -691,8 +691,6 @@ export class RequestClient<Schema extends RequestDefinitions> {
       };
 
       const done = (res: SafeWrap<Error, VoidFunction>) => {
-        closeConnection();
-
         if (resolved) {
           return;
         }
@@ -704,6 +702,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
 
       if (opts.timeout) {
         timeoutId = setTimeout(() => {
+          closeConnection();
           done([new TimeoutError(`error timed out opening connection to SSE endpoint: ${url}`), null]);
         }, opts.timeout);
       }
@@ -733,6 +732,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
 
       connection.onerror = (event: Event) => {
         if (!resolved) {
+          closeConnection();
           done([new Error(`error opening SSE connection`, { cause: event }), null]);
           return;
         }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -819,12 +819,12 @@ export class RequestClient<Schema extends RequestDefinitions> {
       timeout: retryTimeout,
       log: this.#debug,
       errFn: (err) => {
-        if (isAbortError(err)) {
-          return true;
-        }
-
         if (isTimeoutError(err)) {
           return false;
+        }
+
+        if (isAbortError(err)) {
+          return true;
         }
 
         if (isErrorType(TypeError, err)) {

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -4,18 +4,21 @@
  * @module
  */
 
-/** Error thrown when a request is aborted. */
-/** Type guard for {@link AbortError}. */
+/** Error thrown when a request is aborted via AbortController. */
+/** Type guard that checks if an error is an {@link AbortError}. */
 export { AbortError, isAbortError } from './abortError';
-/** Error thrown for non-2xx HTTP responses. */
-/** Extract an {@link HTTPError} from an unknown error. */
-/** Type guard for {@link HTTPError}. */
+/** Error representing a non-2xx HTTP response. */
+/** Extracts an {@link HTTPError} from an unknown error value. */
+/** Type guard that checks if an error is an {@link HTTPError}. */
 export { getHttpError, HTTPError, isHttpError } from './httpError';
 /** Generic type guard that matches an error constructor against an unknown error. */
 export { isErrorType } from './isErrorType';
 /** Error thrown when a request exceeds the configured timeout. */
-/** Type guard for {@link TimeoutError}. */
+/** Type guard that checks if an error is a {@link TimeoutError}. */
 export { isTimeoutError, TimeoutError } from './timeoutError';
-
 /** Recursively unwraps nested causes to find a specific error class. */
 export { unwrapErrorType } from './unwrapErrorType';
+/** Error thrown when validation of payloads fails. */
+/** Type guard that checks if an error is a {@link ValidationError}. */
+/** Extracts a {@link ValidationError} from an unknown error value. */
+export { getValidationError, isValidationError, ValidationError } from './validationError';

--- a/src/fetch/client.test.ts
+++ b/src/fetch/client.test.ts
@@ -84,6 +84,30 @@ describe('FetchClient', () => {
       expect(headers.get('x-base')).toBeNull();
     });
   });
+
+  describe('dispose', () => {
+    it('is a no-op and can be called multiple times', async () => {
+      const successResponse = {
+        ok: true,
+        status: 200,
+      } as FetchResponse;
+
+      const mockedFetch = global.fetch as MockedFunction<typeof fetch>;
+      mockedFetch.mockResolvedValueOnce(successResponse);
+
+      const client = new FetchClient('https://api.example.com', {});
+
+      expect(() => {
+        client.dispose();
+        client.dispose();
+      }).not.toThrow();
+
+      const [err, response] = await client.get('/data', {});
+      expect(err).toBeNull();
+      expect(response).toEqual(successResponse);
+      expect(mockedFetch).toHaveBeenCalledTimes(1);
+    });
+  });
   describe('GET', () => {
     it('should make a get request with JSON body', async () => {
       const responseBody = { id: 123 };

--- a/src/fetch/client.ts
+++ b/src/fetch/client.ts
@@ -50,6 +50,14 @@ export class FetchClient {
   }
 
   /**
+   * Optional lifecycle hook for parity with FetchClientProviderDefinition.
+   * Included for consumers that expect a dispose method.
+   */
+  public dispose(): void {
+    // No resources to clean up in the default implementation.
+  }
+
+  /**
    * Executes a GET request against the given endpoint.
    *
    * @param endpoint - Relative endpoint path (e.g. `users/123`).

--- a/src/fetch/utils.ts
+++ b/src/fetch/utils.ts
@@ -22,7 +22,7 @@ function headerOptionsToObject(h?: HeaderOptions): Record<string, string | undef
 
   const result: Record<string, string | undefined> = {};
   for (const [key, value] of Object.entries(h)) {
-    if (value === null || value === null) {
+    if (value === undefined || value === null) {
       result[key.toLowerCase()] = undefined;
       continue;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,30 @@
  * @module
  */
 
-/** Constructor options for {@link RequestClient}. */
-/** Shape of endpoint definitions consumed by {@link RequestClient}. */
+/** Constructor options accepted by {@link RequestClient}. */
+/** Shape of endpoint definition maps consumed by {@link RequestClient}. */
 export type { RequestClientProps, RequestDefinitions } from './core';
 /** Typed HTTP client for performing validated REST and SSE calls. */
 export { RequestClient } from './core';
-/** Error thrown when a request is aborted via `AbortController`. */
-/** Error thrown when a non-2xx HTTP response is returned. */
-/** Error thrown when a request exceeds its timeout. */
-/** Helper to unwrap an {@link HTTPError} from an unknown error. */
-/** Type guard that checks if an error is {@link AbortError}. */
-/** Type guard that checks if an error is {@link HTTPError}. */
-/** Type guard that checks if an error is {@link TimeoutError}. */
-export { AbortError, getHttpError, HTTPError, isAbortError, isHttpError, isTimeoutError, TimeoutError } from './error';
+/** Error thrown when a request is aborted via AbortController. */
+/** Error representing a non-2xx HTTP response. */
+/** Error thrown when a request exceeds the configured timeout. */
+/** Error thrown when validation of payloads fails. */
+/** Extracts an {@link HTTPError} from an unknown error value. */
+/** Extracts a {@link ValidationError} from an unknown error value. */
+/** Type guard that checks if an error is an {@link AbortError}. */
+/** Type guard that checks if an error is an {@link HTTPError}. */
+/** Type guard that checks if an error is a {@link TimeoutError}. */
+/** Type guard that checks if an error is a {@link ValidationError}. */
+export {
+  AbortError,
+  getHttpError,
+  getValidationError,
+  HTTPError,
+  isAbortError,
+  isHttpError,
+  isTimeoutError,
+  isValidationError,
+  TimeoutError,
+  ValidationError,
+} from './error';

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -165,6 +165,8 @@ export interface FetchClientProviderDefinition {
   delete: (url: string, options: Omit<FetchOptions, 'method' | 'body'>) => SafeWrapAsync<Error, FetchResponse>;
   /** Updates default options for the provider. */
   config: (opts: FetchClientOptions) => void;
+  /** Optional lifecycle hook to dispose resources (e.g., keep-alive agents). */
+  dispose?: () => void;
 }
 
 /** Factory signature for constructing HTTP providers. */

--- a/src/types/sse.ts
+++ b/src/types/sse.ts
@@ -12,7 +12,7 @@ export interface SSEClientSourceEventMap {
 
 /** Init options for SSEClient */
 export interface SSEClientSourceInit {
-  /** Whether to send cookies/credentials with the SSE connection. */
+  /** Whether to send cookies/credentials with the SSE connection. Here will default to what client sets, usually true */
   withCredentials?: boolean;
 }
 

--- a/src/utils/constructUrl.test.ts
+++ b/src/utils/constructUrl.test.ts
@@ -34,4 +34,26 @@ describe('constructUrl', () => {
     expect(err).toBeNull();
     expect(url).toBe('integrations/slack%20github/files/file%2Fname?q=query+param&tag=a%2Bb');
   });
+
+  it('errors when required path params are missing', async () => {
+    const schema = {
+      '/users/{id}': {
+        get: {
+          response: z.string(),
+        },
+      },
+    } satisfies RequestDefinitions;
+
+    const [err, url] = await constructUrl<'get', typeof schema, '/users/{id}'>(
+      '/users/{id}',
+      // @ts-expect-error
+      null,
+      schema['/users/{id}'].get,
+      false,
+    );
+
+    expect(url).toBeNull();
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.message).toContain('path contains {} users/{id}');
+  });
 });

--- a/src/utils/constructUrl.ts
+++ b/src/utils/constructUrl.ts
@@ -23,6 +23,12 @@ export async function constructUrl<
     if (result.startsWith('/')) {
       result = result.substring(1);
     }
+
+    // Check for remaining unreplaced braces
+    if (result.includes('{') || result.includes('}')) {
+      return [new Error(`error constructing URL, path contains {} ${result}`), null];
+    }
+
     return [null, result];
   }
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -6,7 +6,10 @@ export interface RetryOptions<R> {
   name: string;
   /** Function to execute; must return a tuple-style result. */
   fn: () => SafeWrapAsync<Error, R>;
-  /** Maximum number of attempts before giving up. */
+  /**
+   * Maximum number of retries after the initial attempt (total tries = attempts + 1).
+   * Passing 0 means "try once, then stop."
+   */
   attempts?: number;
   /** Milliseconds to wait between attempts. */
   timeout?: number;


### PR DESCRIPTION
- Fixing missing validation issue in constructUrl where no params present caused ignoring of {} (and added tests for it)
- Updated so ignoreStatusCodes as only ignore, not 'retry-everything-else' (and added tests for it)
- Fixing issue with post, put, patch headers being potentially ignored if they are header object instead of record (and included tests)
- Fixing potential security 'oversight' with SSE almost always defaulting to including credentials
- Updated JSDoc for validation default val
- Fixing missing export from barrel-exporter
- Fixing overlapping conditional for null, with missing undefined in fetch-utils
- Fixing SSE connections potentially lagging behind not being closed
