### PR TITLE
refactor: SSE parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Releases
 
 ## Contents
+- [v0.3.2-alpha.3](#v032-alpha3)
 - [v0.3.2-alpha.2](#v032-alpha2)
 - [v0.3.2-alpha.1](#v032-alpha1)
 - [v0.3.2-alpha.0](#v032-alpha0)
@@ -16,6 +17,10 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 - [v0.0.8](#v008)
+
+## v0.3.2-alpha.3
+
+- Improved SSE non-JSON handling; Don't auto-wrap in "", allow type-parsing (ie. allow true/false/numbers), as well as correct multi-line support.
 
 ## v0.3.2-alpha.2
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kasperrt/wiretyped",
-  "version": "0.3.2-alpha.2",
+  "version": "0.3.2-alpha.3",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiretyped",
-  "version": "0.3.2-alpha.2",
+  "version": "0.3.2-alpha.3",
   "description": "Universal fetch-based HTTP client with robust error handling, retries, caching, SSE, and Standard Schema validation.",
   "type": "module",
   "keywords": [

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -8,12 +8,7 @@ import { getRetryExhaustedError, RetryExhaustedError } from '../error/retryExhau
 import { getRetrySuppressedError, RetrySuppressedError } from '../error/retrySuppressedError.js';
 import { TimeoutError } from '../error/timeoutError.js';
 import { ValidationError } from '../error/validationError.js';
-import type {
-  FetchClientProvider,
-  FetchClientProviderDefinition,
-  Options,
-  RequestOptions,
-} from '../types/request.js';
+import type { FetchClientProvider, FetchClientProviderDefinition, Options, RequestOptions } from '../types/request.js';
 import * as signals from '../utils/signals.js';
 import { RequestClient } from './client.js';
 import type { RequestDefinitions } from './types.js';
@@ -1068,7 +1063,7 @@ describe('RequestClient', () => {
       );
     });
 
-    test("No params: returns error when response.blob() throws", async () => {
+    test('No params: returns error when response.blob() throws', async () => {
       const getSpy = vi.spyOn(MOCK_FETCH_PROVIDER.prototype, 'get').mockImplementation(() => {
         const response = {
           blob: () => {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -418,7 +418,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
 
       let eventName = 'message';
       let data = '';
-      let sawData = false;
+      let hasData = false;
       for (const line of block.split(/\r?\n/)) {
         // Safeguard, in reality should never be hit
         /* v8 ignore next -- @preserve */
@@ -452,13 +452,13 @@ export class RequestClient<Schema extends RequestDefinitions> {
 
         if (line.startsWith('data:')) {
           const value = line.slice(5).trim();
-          data += (sawData ? '\n' : '') + value;
-          sawData = true;
+          data += (hasData ? '\n' : '') + value;
+          hasData = true;
         }
       }
 
       // Extra safeguard in case the above breaks in some absurd way
-      if (!sawData) {
+      if (!hasData) {
         return;
       }
 

--- a/src/fetch/utils.test.ts
+++ b/src/fetch/utils.test.ts
@@ -20,14 +20,14 @@ describe('mergeHeaderOptions', () => {
     expect(merged).toEqual(new Headers({ a: 'b', c: 'd' }));
   });
 
-  test('merge objects with bad values', () => {
+  test('merge objects with non-string values coerces to strings', () => {
     // @ts-expect-error
     const merged = mergeHeaderOptions({ a: 1 }, { c: true });
 
     expect(merged).toEqual(new Headers({ a: '1', c: 'true' }));
   });
 
-  test('merge objects with bad values', () => {
+  test('merge objects drops non-primitive values', () => {
     // @ts-expect-error
     const merged = mergeHeaderOptions({ a: 1 }, { c: true, badValue: { nested: 'data' } });
 

--- a/src/utils/tryParse.test.ts
+++ b/src/utils/tryParse.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { tryParse } from './tryParse.js';
+
+describe('tryParse', () => {
+  it('parses JSON objects', () => {
+    expect(tryParse('{"a":1,"b":"c"}')).toEqual({ a: 1, b: 'c' });
+  });
+
+  it('parses JSON arrays', () => {
+    expect(tryParse('[1,2,3]')).toEqual([1, 2, 3]);
+  });
+
+  it('parses JSON primitives', () => {
+    expect(tryParse('"hello"')).toBe('hello');
+    expect(tryParse('123')).toBe(123);
+    expect(tryParse('true')).toBe(true);
+    expect(tryParse('null')).toBeNull();
+  });
+
+  it('returns the original input when JSON is invalid', () => {
+    expect(tryParse('{')).toBe('{');
+    expect(tryParse('01')).toBe('01');
+    expect(tryParse('not json')).toBe('not json');
+  });
+
+  it('does not throw (returns input on parse errors)', () => {
+    expect(() => tryParse('{bad json}')).not.toThrow();
+    expect(tryParse('{bad json}')).toBe('{bad json}');
+  });
+
+  it('treats whitespace-only as invalid JSON and returns input unchanged', () => {
+    expect(tryParse('   ')).toBe('   ');
+  });
+});

--- a/src/utils/tryParse.ts
+++ b/src/utils/tryParse.ts
@@ -1,0 +1,19 @@
+import { safeWrap } from './wrap';
+
+/**
+ * Attempts to parse a string as JSON.
+ *
+ * If parsing succeeds, returns the parsed value; otherwise returns the original input unchanged.
+ * This function never throws.
+ *
+ * @param input - The string to parse.
+ * @returns The parsed JSON value, or `input` if it isn't valid JSON.
+ */
+export function tryParse(input: string): unknown {
+  const [errParsed, parsed] = safeWrap(() => JSON.parse(input));
+  if (errParsed) {
+    return input;
+  }
+
+  return parsed;
+}


### PR DESCRIPTION
Improve SSE parsing by a great lot.

- Improve SSE parsing (buffering + block splitting)
- Support CRLF (\r\n\r\n) block delimiters
- Buffer across chunk boundaries so events/data lines split across reads are handled
- Treat empty data: as an empty payload
- Flush the final unterminated block when the stream closes
- Include more tests to validate that input/output for SSE is correct
- Add tryParse function to try to parse JSON, if not return whatever input was from before
