### PR TITLE
refactor: getResponseData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Releases
 
 ## Contents
+- [v0.3.4-alpha.0](#v0-3-4-alpha-0)
 - [v0.3.3](#v0-3-3)
 - [v0.3.2](#v0-3-2)
 - [v0.3.1](#v0-3-1)
@@ -15,6 +16,12 @@
 - [v0.1.1](#v0-1-1)
 - [v0.1.0](#v0-1-0)
 - [v0.0.8](#v0-0-8)
+
+## v0.3.4-alpha.0
+
+- Internal; Handle 205 status-codes more gracefully by defaulting to null returned as body.
+- Internal; Reduce overhead for getResponseData to read response once through `.text()` with attempting parsing on `application/json` or `+json` in the `Content-Type` header.
+
 
 ## v0.3.3
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kasperrt/wiretyped",
-  "version": "0.3.3",
+  "version": "0.3.4-alpha.0",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiretyped",
-  "version": "0.3.3",
+  "version": "0.3.4.alpha-0",
   "description": "Universal fetch-based HTTP client with robust error handling, retries, caching, SSE, and Standard Schema validation.",
   "type": "module",
   "keywords": [

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -663,7 +663,9 @@ describe('RequestClient', () => {
           json: () => {
             throw new Error('test');
           },
-          text: () => '{ "ok": true }',
+          text: () => {
+            throw new Error('test');
+          },
           ok: true,
           status: 200,
           headers: { get: () => 'application/json' },
@@ -700,7 +702,7 @@ describe('RequestClient', () => {
         new Error('error doing request in get', {
           cause: new RetryExhaustedError('error retries exhausted', 10, {
             cause: new Error('error getting response in GET', {
-              cause: new Error('error parsing json in getResponseData', { cause: new Error('test') }),
+              cause: new Error('error reading response body in getResponseData', { cause: new Error('test') }),
             }),
           }),
         }),
@@ -1381,7 +1383,7 @@ describe('RequestClient', () => {
         const getSpy = vi.spyOn(MOCK_FETCH_PROVIDER.prototype, 'get').mockImplementation(async () =>
           asyncOk({
             json: () => null,
-            text: () => '{ "data": "GET request data no params" }',
+            text: () => '{ "foo": "GET request data no params" }',
             ok: true,
             status: 200,
             headers: { get: () => 'application/json' },

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -428,6 +428,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
     const close = (): void => controller.abort('closed by user request');
     const hasEventSchema = (name: string): name is SSEDataReturn<Schema, Endpoint & string>['type'] =>
       name in eventSchemas;
+
     const parseBlock = async (block: string) => {
       if (!block) {
         return;

--- a/src/utils/getResponseData.test.ts
+++ b/src/utils/getResponseData.test.ts
@@ -91,7 +91,7 @@ describe('getResponseData', () => {
 
       expect(value).toBeNull();
       expect(err).toBeInstanceOf(Error);
-      expect(err?.message).toBe('error attempting string parse after json failed in getResponseData');
+      expect(err?.message).toBe('error reading response body in getResponseData');
       expect(err?.cause).toBe(textError);
     });
 
@@ -111,7 +111,7 @@ describe('getResponseData', () => {
 
       expect(value).toBeNull();
       expect(err).toBeInstanceOf(Error);
-      expect(err?.message).toBe('error json-parse string after json failed in getResponseData');
+      expect(err?.message).toBe('error parsing json response body in getResponseData');
       expect(err?.cause).toBeInstanceOf(SyntaxError);
     });
 


### PR DESCRIPTION
- Internal; Handle 205 status-codes more gracefully by defaulting to null returned as body.
- Internal; Reduce overhead for getResponseData to read response once through `.text()` with attempting parsing on `application/json` or `+json` in the `Content-Type` header.
