### PR TITLE
refactor: Minor error changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
-    paths:
-      - "jsr.json"
-      - "package.json"
-      - "CHANGELOG.md"
+    tags: ["v*"]
 
 permissions:
   id-token: write
@@ -19,13 +16,14 @@ concurrency:
 
 jobs:
   detect:
-    if: github.repository == 'kasperrt/wiretyped'
+    if: ${{ github.repository == 'kasperrt/wiretyped' && !(startsWith(github.ref, 'refs/tags/') && github.actor == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
 
     outputs:
       tag: ${{ steps.out.outputs.tag }}
       version: ${{ steps.out.outputs.version }}
-      created: ${{ steps.out.outputs.created }}
+      run: ${{ steps.out.outputs.run }}
+      create_tag: ${{ steps.out.outputs.create_tag }}
 
     steps:
       - name: Checkout
@@ -33,46 +31,91 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read and validate versions
-        id: ver
+      - name: Determine tag/version
+        id: meta
         shell: bash
         run: |
           set -euo pipefail
 
-          if [ ! -f "jsr.json" ]; then
-            echo "ERROR: jsr.json not found"
-            exit 1
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+
+            if [[ "$TAG" != v* ]]; then
+              echo "ERROR: Tag must start with 'v' (got: $TAG)"
+              exit 1
+            fi
+
+            VERSION="${TAG#v}"
+
+            if [ -z "$VERSION" ]; then
+              echo "ERROR: Tag version is empty (got: $TAG)"
+              exit 1
+            fi
+
+            JSR_VERSION="$(jq -r '.version // empty' jsr.json)"
+            PKG_VERSION="$(jq -r '.version // empty' package.json)"
+
+            if [ -z "$JSR_VERSION" ] || [ -z "$PKG_VERSION" ]; then
+              echo "ERROR: Missing version in jsr.json or package.json"
+              exit 1
+            fi
+
+            if [ "$JSR_VERSION" != "$PKG_VERSION" ]; then
+              echo "ERROR: Version mismatch!"
+              echo "  jsr.json     : $JSR_VERSION"
+              echo "  package.json : $PKG_VERSION"
+              exit 1
+            fi
+
+            if [ "$JSR_VERSION" != "$VERSION" ]; then
+              echo "ERROR: Tag does not match versions!"
+              echo "  tag          : $TAG"
+              echo "  jsr.json     : $JSR_VERSION"
+              echo "  package.json : $PKG_VERSION"
+              exit 1
+            fi
+
+            echo "is_tag_push=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          else
+            if [ ! -f "jsr.json" ]; then
+              echo "ERROR: jsr.json not found"
+              exit 1
+            fi
+
+            if [ ! -f "package.json" ]; then
+              echo "ERROR: package.json not found"
+              exit 1
+            fi
+
+            JSR_VERSION="$(jq -r '.version // empty' jsr.json)"
+            PKG_VERSION="$(jq -r '.version // empty' package.json)"
+
+            if [ -z "$JSR_VERSION" ] || [ -z "$PKG_VERSION" ]; then
+              echo "ERROR: Missing version in jsr.json or package.json"
+              exit 1
+            fi
+
+            if [ "$JSR_VERSION" != "$PKG_VERSION" ]; then
+              echo "ERROR: Version mismatch!"
+              echo "  jsr.json     : $JSR_VERSION"
+              echo "  package.json : $PKG_VERSION"
+              exit 1
+            fi
+
+            echo "is_tag_push=false" >> "$GITHUB_OUTPUT"
+            echo "tag=v$JSR_VERSION" >> "$GITHUB_OUTPUT"
+            echo "version=$JSR_VERSION" >> "$GITHUB_OUTPUT"
           fi
-
-          if [ ! -f "package.json" ]; then
-            echo "ERROR: package.json not found"
-            exit 1
-          fi
-
-          JSR_VERSION="$(jq -r '.version // empty' jsr.json)"
-          PKG_VERSION="$(jq -r '.version // empty' package.json)"
-
-          if [ -z "$JSR_VERSION" ] || [ -z "$PKG_VERSION" ]; then
-            echo "ERROR: Missing version in jsr.json or package.json"
-            exit 1
-          fi
-
-          if [ "$JSR_VERSION" != "$PKG_VERSION" ]; then
-            echo "ERROR: Version mismatch!"
-            echo "  jsr.json     : $JSR_VERSION"
-            echo "  package.json : $PKG_VERSION"
-            exit 1
-          fi
-
-          echo "version=$JSR_VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$JSR_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if tag exists
         id: exists
+        if: steps.meta.outputs.is_tag_push == 'false'
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${{ steps.ver.outputs.tag }}"
+          TAG="${{ steps.meta.outputs.tag }}"
           git fetch --tags
 
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
@@ -85,36 +128,40 @@ jobs:
         id: out
         shell: bash
         env:
-          TAG: ${{ steps.ver.outputs.tag }}
-          VERSION: ${{ steps.ver.outputs.version }}
+          IS_TAG_PUSH: ${{ steps.meta.outputs.is_tag_push }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
           EXISTS: ${{ steps.exists.outputs.exists }}
         run: |
           set -euo pipefail
 
-          if [ "$EXISTS" = "false" ]; then
-            CREATED="true"
+          if [ "$IS_TAG_PUSH" = "true" ]; then
+            RUN="true"
+            CREATE_TAG="false"
           else
-            CREATED="false"
+            if [ "${EXISTS:-false}" = "false" ]; then
+              RUN="true"
+              CREATE_TAG="true"
+            else
+              RUN="false"
+              CREATE_TAG="false"
+            fi
           fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "created=$CREATED" >> "$GITHUB_OUTPUT"
+          echo "run=$RUN" >> "$GITHUB_OUTPUT"
+          echo "create_tag=$CREATE_TAG" >> "$GITHUB_OUTPUT"
 
   ci:
-    if: github.repository == 'kasperrt/wiretyped' && needs.detect.outputs.created == 'true'
+    if: github.repository == 'kasperrt/wiretyped' && needs.detect.outputs.run == 'true'
     needs: [detect]
     uses: ./.github/workflows/ci.yml
 
   tag:
-    if: github.repository == 'kasperrt/wiretyped' && needs.detect.outputs.created == 'true'
+    if: github.repository == 'kasperrt/wiretyped' && needs.detect.outputs.run == 'true' && needs.ci.result == 'success'
     needs: [detect, ci]
     runs-on: ubuntu-latest
-
-    outputs:
-      tag: ${{ steps.out.outputs.tag }}
-      version: ${{ steps.out.outputs.version }}
-      created: ${{ steps.out.outputs.created }}
 
     steps:
       - name: Checkout
@@ -137,7 +184,7 @@ jobs:
           fi
 
       - name: Create and push tag
-        if: steps.exists.outputs.exists == 'false'
+        if: needs.detect.outputs.create_tag == 'true' && steps.exists.outputs.exists == 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -149,29 +196,9 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
 
-      - name: Export job outputs
-        id: out
-        shell: bash
-        env:
-          TAG: ${{ needs.detect.outputs.tag }}
-          VERSION: ${{ needs.detect.outputs.version }}
-          EXISTS: ${{ steps.exists.outputs.exists }}
-        run: |
-          set -euo pipefail
-
-          if [ "$EXISTS" = "false" ]; then
-            CREATED="true"
-          else
-            CREATED="false"
-          fi
-
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "created=$CREATED" >> "$GITHUB_OUTPUT"
-
   release:
-    if: github.repository == 'kasperrt/wiretyped' && needs.tag.outputs.created == 'true'
-    needs: [tag]
+    if: github.repository == 'kasperrt/wiretyped' && needs.detect.outputs.run == 'true' && needs.ci.result == 'success' && needs.tag.result == 'success'
+    needs: [detect, ci, tag]
     runs-on: ubuntu-latest
 
     steps:
@@ -184,7 +211,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${{ needs.tag.outputs.tag }}"
+          TAG="${{ needs.detect.outputs.tag }}"
           git fetch --tags
           git checkout "$TAG"
 
@@ -209,7 +236,7 @@ jobs:
           fi
 
           EXPECTED="v$JSR_VERSION"
-          TAG="${{ needs.tag.outputs.tag }}"
+          TAG="${{ needs.detect.outputs.tag }}"
 
           if [ "$TAG" != "$EXPECTED" ]; then
             echo "ERROR: Tag does not match versions!"
@@ -237,7 +264,7 @@ jobs:
       - name: Determine npm dist-tag
         id: npm_tag
         env:
-          VERSION: ${{ needs.tag.outputs.version }}
+          VERSION: ${{ needs.detect.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -272,51 +299,3 @@ jobs:
 
       - name: Publish to JSR
         run: pnpx jsr publish
-
-  docs:
-    if: github.repository == 'kasperrt/wiretyped' && needs.tag.outputs.created == 'true'
-    needs: [tag, release]
-    runs-on: ubuntu-latest
-
-    environment:
-      name: github-pages
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Checkout tag
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="${{ needs.tag.outputs.tag }}"
-          git fetch --tags
-          git checkout "$TAG"
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.26.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build docs (GitHub Pages)
-        env:
-          DOCS_BASE: "/"
-        run: pnpm docs:build
-
-      - uses: actions/configure-pages@v5
-
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/.vitepress/dist
-
-      - id: deployment
-        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Releases
 
 ## Contents
+- [v0.3.4-alpha.1](#v0-3-4-alpha-1)
 - [v0.3.4-alpha.0](#v0-3-4-alpha-0)
 - [v0.3.3](#v0-3-3)
 - [v0.3.2](#v0-3-2)
@@ -16,6 +17,12 @@
 - [v0.1.1](#v0-1-1)
 - [v0.1.0](#v0-1-0)
 - [v0.0.8](#v0-0-8)
+
+## v0.3.4-alpha.1
+
+- Remove unused shallow flag from isErrorType as it is totally unnecessary.
+- Update name on error-classes to be static for better accessibility.
+- Internal; Use unwrapErrorType + isErrorType internally rather than larger getters and checkers.
 
 ## v0.3.4-alpha.0
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kasperrt/wiretyped",
-  "version": "0.3.4-alpha.0",
+  "version": "0.3.4-alpha.1",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiretyped",
-  "version": "0.3.4-alpha.0",
+  "version": "0.3.4-alpha.1",
   "description": "Universal fetch-based HTTP client with robust error handling, retries, caching, SSE, and Standard Schema validation.",
   "type": "module",
   "keywords": [

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,8 +1,8 @@
 import { CacheClient } from '../cache/client.js';
 import { isAbortError } from '../error/abortError.js';
-import { getHttpError, HTTPError } from '../error/httpError.js';
-import { isErrorType } from '../error/isErrorType.js';
-import { isTimeoutError } from '../error/timeoutError.js';
+import { HTTPError } from '../error/httpError.js';
+import { TimeoutError } from '../error/timeoutError.js';
+import { unwrapErrorType } from '../error/unwrapErrorType.js';
 import { FetchClient } from '../fetch/client.js';
 import { mergeHeaderOptions } from '../fetch/utils.js';
 import type {
@@ -749,7 +749,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       attempts: retryAttempts,
       timeout: retryTimeout,
       errFn: (err) => {
-        if (isTimeoutError(err)) {
+        if (unwrapErrorType(TimeoutError, err)) {
           return false;
         }
 
@@ -757,11 +757,11 @@ export class RequestClient<Schema extends RequestDefinitions> {
           return true;
         }
 
-        if (isErrorType(TypeError, err)) {
+        if (unwrapErrorType(TypeError, err)) {
           return false;
         }
 
-        const httpError = getHttpError(err);
+        const httpError = unwrapErrorType(HTTPError, err);
         if (!httpError) {
           return false;
         }

--- a/src/error/abortError.ts
+++ b/src/error/abortError.ts
@@ -5,7 +5,7 @@ import { isErrorType } from './isErrorType.js';
  */
 export class AbortError extends Error {
   /** AbortError error-name */
-  name = 'AbortError';
+  static name = 'AbortError';
 }
 
 /**

--- a/src/error/constructUrlError.test.ts
+++ b/src/error/constructUrlError.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { ConstructURLError, getConstructURLError, isConstructURLError } from './constructUrlError.js';
+
+describe('ConstructURLError', () => {
+  it('exposes url via getter', () => {
+    const err = new ConstructURLError('bad url', 'https://example.com');
+    expect(err.url).toBe('https://example.com');
+  });
+});
+
+describe('isConstructURLError', () => {
+  it('returns true for instances of ConstructURLError', () => {
+    const err = new ConstructURLError('bad url', 'https://example.com');
+    expect(isConstructURLError(err)).toBe(true);
+  });
+
+  it('returns false for non ConstructURLError errors', () => {
+    expect(isConstructURLError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('getConstructURLError', () => {
+  it('returns the error when passed directly', () => {
+    const err = new ConstructURLError('bad url', 'https://example.com');
+    expect(getConstructURLError(err)).toBe(err);
+  });
+
+  it('unwraps nested causes', () => {
+    const err = new ConstructURLError('bad url', 'https://example.com');
+    const wrapped = new Error('outer', { cause: err });
+    expect(getConstructURLError(wrapped)).toBe(err);
+  });
+
+  it('returns null when no ConstructURLError exists', () => {
+    const wrapped = new Error('outer', { cause: new Error('inner') });
+    expect(getConstructURLError(wrapped)).toBeNull();
+  });
+});

--- a/src/error/constructUrlError.ts
+++ b/src/error/constructUrlError.ts
@@ -6,7 +6,7 @@ import { unwrapErrorType } from './unwrapErrorType.js';
  */
 export class ConstructURLError extends Error {
   /** ConstructURLError error-name */
-  name = 'ConstructURLError';
+  static name = 'ConstructURLError';
   /** Internal URL for what it looked like */
   #url: string;
 
@@ -32,6 +32,6 @@ export function getConstructURLError(error: unknown): null | ConstructURLError {
 /**
  * Type guard for {@link ConstructURLError}.
  */
-export function isConstructURLError(error: unknown, shallow?: boolean): error is ConstructURLError {
-  return isErrorType(ConstructURLError, error, shallow);
+export function isConstructURLError(error: unknown): error is ConstructURLError {
+  return isErrorType(ConstructURLError, error);
 }

--- a/src/error/httpError.ts
+++ b/src/error/httpError.ts
@@ -7,7 +7,7 @@ import { unwrapErrorType } from './unwrapErrorType.js';
  */
 export class HTTPError extends Error {
   /** HTTPError error-name */
-  name = 'HTTPError';
+  static name = 'HTTPError';
 
   /** Response causing the HTTPError */
   #response: FetchResponse;
@@ -36,6 +36,6 @@ export function getHttpError(error: unknown): null | HTTPError {
 /**
  * Type guard for {@link HTTPError}.
  */
-export function isHttpError(error: unknown, shallow?: boolean): error is HTTPError {
-  return isErrorType(HTTPError, error, shallow);
+export function isHttpError(error: unknown): error is HTTPError {
+  return isErrorType(HTTPError, error);
 }

--- a/src/error/isErrorType.test.ts
+++ b/src/error/isErrorType.test.ts
@@ -51,19 +51,6 @@ describe('isErrorType', () => {
     expect(isErrorType(CustomError, wrapped7)).toEqual(true);
   });
 
-  it('expect 7 layers deep but shallow check to correctly return false', () => {
-    const err = new CustomError('test');
-    const wrapped1 = new Error('err1', { cause: err });
-    const wrapped2 = new Error('err2', { cause: wrapped1 });
-    const wrapped3 = new Error('err3', { cause: wrapped2 });
-    const wrapped4 = new Error('err4', { cause: wrapped3 });
-    const wrapped5 = new Error('err5', { cause: wrapped4 });
-    const wrapped6 = new Error('err6', { cause: wrapped5 });
-    const wrapped7 = new Error('err7', { cause: wrapped6 });
-
-    expect(isErrorType(CustomError, wrapped7, true)).toEqual(false);
-  });
-
   it('expect 4 layers deep to correctly return true, even though self wraps another', () => {
     const original = new Error('first');
     const err = new CustomError('test', { cause: original });

--- a/src/error/isErrorType.ts
+++ b/src/error/isErrorType.ts
@@ -8,11 +8,6 @@ export function isErrorType<T extends Error>(
   // biome-ignore lint/suspicious/noExplicitAny: errorClass needs to handle any type of class handling, hence the any class-type
   errorClass: new (...args: any[]) => T,
   err: unknown,
-  shallow = false,
 ): err is T {
-  if (shallow) {
-    return err instanceof errorClass;
-  }
-
   return Boolean(unwrapErrorType(errorClass, err));
 }

--- a/src/error/retryExhaustedError.test.ts
+++ b/src/error/retryExhaustedError.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getRetryExhaustedError, isRetryExhaustedError, RetryExhaustedError } from './retryExhaustedError.js';
+
+describe('RetryExhaustedError', () => {
+  it('exposes attempts via getter', () => {
+    const err = new RetryExhaustedError('retries exhausted', 3);
+    expect(err.attempts).toBe(3);
+  });
+});
+
+describe('isRetryExhaustedError', () => {
+  it('returns true for instances of RetryExhaustedError', () => {
+    const err = new RetryExhaustedError('retries exhausted', 3);
+    expect(isRetryExhaustedError(err)).toBe(true);
+  });
+
+  it('returns false for non RetryExhaustedError errors', () => {
+    expect(isRetryExhaustedError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('getRetryExhaustedError', () => {
+  it('returns the error when passed directly', () => {
+    const err = new RetryExhaustedError('retries exhausted', 3);
+    expect(getRetryExhaustedError(err)).toBe(err);
+  });
+
+  it('unwraps nested causes', () => {
+    const err = new RetryExhaustedError('retries exhausted', 3);
+    const wrapped = new Error('outer', { cause: err });
+    expect(getRetryExhaustedError(wrapped)).toBe(err);
+  });
+
+  it('returns null when no RetryExhaustedError exists', () => {
+    const wrapped = new Error('outer', { cause: new Error('inner') });
+    expect(getRetryExhaustedError(wrapped)).toBeNull();
+  });
+});

--- a/src/error/retryExhaustedError.ts
+++ b/src/error/retryExhaustedError.ts
@@ -6,7 +6,7 @@ import { unwrapErrorType } from './unwrapErrorType.js';
  */
 export class RetryExhaustedError extends Error {
   /** RetryExhaustedError error-name */
-  name = 'RetryExhaustedError';
+  static name = 'RetryExhaustedError';
   /** Internal attempts tried before retry was exhausted */
   #attempts: number;
 
@@ -32,6 +32,6 @@ export function getRetryExhaustedError(error: unknown): null | RetryExhaustedErr
 /**
  * Type guard for {@link RetryExhaustedError}.
  */
-export function isRetryExhaustedError(error: unknown, shallow?: boolean): error is RetryExhaustedError {
-  return isErrorType(RetryExhaustedError, error, shallow);
+export function isRetryExhaustedError(error: unknown): error is RetryExhaustedError {
+  return isErrorType(RetryExhaustedError, error);
 }

--- a/src/error/retrySuppressedError.test.ts
+++ b/src/error/retrySuppressedError.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getRetrySuppressedError, isRetrySuppressedError, RetrySuppressedError } from './retrySuppressedError.js';
+
+describe('RetrySuppressedError', () => {
+  it('exposes attempts via getter', () => {
+    const err = new RetrySuppressedError('retries suppressed', 2);
+    expect(err.attempts).toBe(2);
+  });
+});
+
+describe('isRetrySuppressedError', () => {
+  it('returns true for instances of RetrySuppressedError', () => {
+    const err = new RetrySuppressedError('retries suppressed', 2);
+    expect(isRetrySuppressedError(err)).toBe(true);
+  });
+
+  it('returns false for non RetrySuppressedError errors', () => {
+    expect(isRetrySuppressedError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('getRetrySuppressedError', () => {
+  it('returns the error when passed directly', () => {
+    const err = new RetrySuppressedError('retries suppressed', 2);
+    expect(getRetrySuppressedError(err)).toBe(err);
+  });
+
+  it('unwraps nested causes', () => {
+    const err = new RetrySuppressedError('retries suppressed', 2);
+    const wrapped = new Error('outer', { cause: err });
+    expect(getRetrySuppressedError(wrapped)).toBe(err);
+  });
+
+  it('returns null when no RetrySuppressedError exists', () => {
+    const wrapped = new Error('outer', { cause: new Error('inner') });
+    expect(getRetrySuppressedError(wrapped)).toBeNull();
+  });
+});

--- a/src/error/retrySuppressedError.ts
+++ b/src/error/retrySuppressedError.ts
@@ -6,7 +6,7 @@ import { unwrapErrorType } from './unwrapErrorType.js';
  */
 export class RetrySuppressedError extends Error {
   /** RetrySuppressedError error-name */
-  name = 'RetrySuppressedError';
+  static name = 'RetrySuppressedError';
   /** Internal attempts tried before retry was suppressed */
   #attempts: number;
 
@@ -32,6 +32,6 @@ export function getRetrySuppressedError(error: unknown): null | RetrySuppressedE
 /**
  * Type guard for {@link RetrySuppressedError}.
  */
-export function isRetrySuppressedError(error: unknown, shallow?: boolean): error is RetrySuppressedError {
-  return isErrorType(RetrySuppressedError, error, shallow);
+export function isRetrySuppressedError(error: unknown): error is RetrySuppressedError {
+  return isErrorType(RetrySuppressedError, error);
 }

--- a/src/error/timeoutError.test.ts
+++ b/src/error/timeoutError.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { isTimeoutError, TimeoutError } from './timeoutError.js';
+
+describe('isTimeoutError', () => {
+  it('returns true for instances of TimeoutError', () => {
+    const err = new TimeoutError('timed out');
+    expect(isTimeoutError(err)).toBe(true);
+  });
+
+  it('returns false for non TimeoutError errors', () => {
+    expect(isTimeoutError(new Error('boom'))).toBe(false);
+  });
+});

--- a/src/error/timeoutError.ts
+++ b/src/error/timeoutError.ts
@@ -5,7 +5,7 @@ import { isErrorType } from './isErrorType.js';
  */
 export class TimeoutError extends Error {
   /** TimeoutError error-name */
-  name = 'TimeoutError';
+  static name = 'TimeoutError';
 }
 
 /**

--- a/src/error/validationError.ts
+++ b/src/error/validationError.ts
@@ -7,7 +7,7 @@ import { unwrapErrorType } from './unwrapErrorType.js';
  */
 export class ValidationError extends Error {
   /** ValidationError error-name */
-  name = 'ValidationError';
+  static name = 'ValidationError';
   /** Schema validation issues */
   issues: StandardSchemaV1.Issue[];
 


### PR DESCRIPTION
- Remove unused shallow flag from isErrorType as it is totally unnecessary.
- Update name on error-classes to be static for better accessibility.
- Internal; Use unwrapErrorType + isErrorType internally rather than larger getters and checkers.
