### PR TITLE
refactor: Internal patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Releases
 
 ## Contents
+- [v0.3.4-alpha.2](#v0-3-4-alpha-2)
 - [v0.3.4-alpha.1](#v0-3-4-alpha-1)
 - [v0.3.4-alpha.0](#v0-3-4-alpha-0)
 - [v0.3.3](#v0-3-3)
@@ -17,6 +18,13 @@
 - [v0.1.1](#v0-1-1)
 - [v0.1.0](#v0-1-0)
 - [v0.0.8](#v0-0-8)
+
+## v0.3.4-alpha.2
+
+- Internal; Better handle path to string for constructing URLs.
+- Internal; Fix missing trailing `.js` from import in `tryParse.ts` for ESM compatibility.
+- Internal; Simplify retrier to not be recursive in-case heap goes wild.
+- Internal; Cache-client non-arrow functions.
 
 ## v0.3.4-alpha.1
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kasperrt/wiretyped",
-  "version": "0.3.4-alpha.1",
+  "version": "0.3.4-alpha.2",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiretyped",
-  "version": "0.3.4-alpha.1",
+  "version": "0.3.4-alpha.2",
   "description": "Universal fetch-based HTTP client with robust error handling, retries, caching, SSE, and Standard Schema validation.",
   "type": "module",
   "keywords": [

--- a/src/cache/client.ts
+++ b/src/cache/client.ts
@@ -108,7 +108,7 @@ export class CacheClient {
    * @param {string} key - cache key
    * @param {Promise} request - http request to put in the pending object
    */
-  #addPendingRequest = <T = unknown>(key: string, request: () => SafeWrapAsync<Error, T>, ttl: number) => {
+  #addPendingRequest<T = unknown>(key: string, request: () => SafeWrapAsync<Error, T>, ttl: number) {
     const pending = (async (): SafeWrapAsync<Error, T> => {
       const [errWrapped, wrapped] = await safeWrapAsync(() => request());
       if (errWrapped) {
@@ -129,18 +129,14 @@ export class CacheClient {
 
     this.#pending.set(key, pending);
     return pending;
-  };
+  }
 
   /**
    * Pass a request to the cache
    * @param {string} key - cache key
    * @param {Function} res - http request and data returned.
    */
-  public get = <T = unknown>(
-    key: string,
-    res: () => SafeWrapAsync<Error, T>,
-    ttl = this.#ttl,
-  ): SafeWrapAsync<Error, T> => {
+  public get<T = unknown>(key: string, res: () => SafeWrapAsync<Error, T>, ttl = this.#ttl): SafeWrapAsync<Error, T> {
     const cachedData = this.#getItem<CacheItem<T>>(key);
     if (cachedData) {
       return Promise.resolve([null, cachedData.data]);
@@ -152,7 +148,7 @@ export class CacheClient {
     }
 
     return this.#addPendingRequest(key, res, ttl);
-  };
+  }
 
   /**
    * Constructs a deterministic, unambiguous cache key based on URL + headers.
@@ -179,7 +175,7 @@ export class CacheClient {
    * cleanup that does housekeeping every 30 seconds, removing
    * invalid cache items to prevent unecessary memory usage;
    */
-  #cleanup = () => {
+  #cleanup() {
     clearInterval(this.#intervalId);
 
     this.#intervalId = setInterval(() => {
@@ -187,5 +183,5 @@ export class CacheClient {
         this.#getItem(key);
       }
     }, this.#cleanupInterval);
-  };
+  }
 }

--- a/src/error/isErrorType.ts
+++ b/src/error/isErrorType.ts
@@ -1,4 +1,4 @@
-import { unwrapErrorType } from './unwrapErrorType';
+import { unwrapErrorType } from './unwrapErrorType.js';
 
 /**
  * Generic type guard to check if an unknown error matches a specific error class.

--- a/src/utils/constructUrl.ts
+++ b/src/utils/constructUrl.ts
@@ -18,11 +18,11 @@ export async function constructUrl<
   validation?: boolean,
 ): SafeWrapAsync<Error, string> {
   const searchParams = new URLSearchParams();
-  let result = path.toString();
+  let result = String(path);
 
   // Strip leading slash for clean concatenation with baseUrl
   if (result.startsWith('/')) {
-    result = result.substring(1);
+    result = result.slice(1);
   }
 
   if (!params) {
@@ -68,7 +68,7 @@ export async function constructUrl<
     }
 
     for (const [key, value] of Object.entries(data ?? {})) {
-      result = result.replace(new RegExp(`{${key}}`, 'g'), encodeURIComponent(String(value)));
+      result = result.split(`{${key}}`).join(encodeURIComponent(String(value)));
     }
   }
 
@@ -80,7 +80,7 @@ export async function constructUrl<
     }
 
     if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-      result = result.replace(new RegExp(`{${key}}`, 'g'), encodeURIComponent(String(value)));
+      result = result.split(`{${key}}`).join(encodeURIComponent(String(value)));
     }
   }
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -32,13 +32,13 @@ export interface RetryOptions<R> {
  * @param timeout how long the wait-time should be
  * @param errFn optional errorFunction on whether we want to skip retrying and propagate the error (true = stop, false = retry and move on)
  */
-export function retry<R = unknown>({
+export async function retry<R = unknown>({
   fn,
   attempts = 10,
   timeout = 1000,
   errFn,
 }: RetryOptions<R>): SafeWrapAsync<Error, R> {
-  const retrier = async (fn: () => SafeWrapAsync<Error, R>, attempt = 1): SafeWrapAsync<Error, R> => {
+  for (let attempt = 1; ; attempt += 1) {
     const [err, data] = await fn();
     if (!err) {
       return [null, data];
@@ -53,8 +53,5 @@ export function retry<R = unknown>({
     }
 
     await sleep(timeout);
-    return retrier(fn, attempt + 1);
-  };
-
-  return retrier(fn);
+  }
 }

--- a/src/utils/tryParse.ts
+++ b/src/utils/tryParse.ts
@@ -1,4 +1,4 @@
-import { safeWrap } from './wrap';
+import { safeWrap } from './wrap.js';
 
 /**
  * Attempts to parse a string as JSON.

--- a/src/utils/validator.test.ts
+++ b/src/utils/validator.test.ts
@@ -93,6 +93,6 @@ describe('validate', () => {
     const [err, value] = await validator('test', schema);
 
     expect(value).toBe('test');
-    expect(err).toBeNull;
+    expect(err).toBeNull();
   });
 });


### PR DESCRIPTION
- Internal; Better handle path to string for constructing URLs.
- Internal; Fix missing trailing `.js` from import in `tryParse.ts` for ESM compatibility.
- Internal; Simplify retrier to not be recursive in-case heap goes wild.
- Internal; Cache-client non-arrow functions.
