### PR TITLE
feat: errorConnect sse-option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Releases
 
 ## Contents
+- [v0.3.5-alpha.1](#v0-3-5-alpha-1)
 - [v0.3.4](#v0-3-4)
 - [v0.3.3](#v0-3-3)
 - [v0.3.2](#v0-3-2)
@@ -16,6 +17,10 @@
 - [v0.1.1](#v0-1-1)
 - [v0.1.0](#v0-1-0)
 - [v0.0.8](#v0-0-8)
+
+## v0.3.5-alpha.1
+
+- Add `errorConnect` option to `client.sse(...)` for forwarding open/reconnect/read errors to the SSE handler.
 
 ## v0.3.4
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
       {
         text: versionLabel,
         items: [
+          { text: 'v0.3.4', link: 'https://github.com/kasperrt/wiretyped/tree/v0.3.4' },
           { text: 'v0.3.3', link: 'https://github.com/kasperrt/wiretyped/tree/v0.3.3' },
           { text: 'v0.3.2', link: 'https://github.com/kasperrt/wiretyped/tree/v0.3.2' },
           { text: 'v0.3.1', link: 'https://github.com/kasperrt/wiretyped/tree/v0.3.1' },

--- a/docs/guide/methods.md
+++ b/docs/guide/methods.md
@@ -249,8 +249,11 @@ SSE options mirror fetch options except method/body/keepalive, plus:
   credentials?: RequestCredentials;
   signal?: AbortSignal;
   errorUnknownType?: boolean;
+  errorConnect?: boolean;
 }
 ```
+
+When `errorConnect` is `true`, connection/open/reconnect/read failures are forwarded to the handler as `Error('error on open connection', { cause })`; non-OK connection responses use `HTTPError` as `cause`.
 
 For more details (type narrowing, reconnection behavior, `Last-Event-ID`), see [`/guide/sse`](/guide/sse).
 

--- a/docs/guide/sse.md
+++ b/docs/guide/sse.md
@@ -11,6 +11,8 @@ WireTyped supports typed SSE streams via `client.sse(endpoint, params, handler, 
 - The client builds URLs with path/query validation just like HTTP requests.
 - Messages are parsed as JSON and validated against the typed event schema by default; set `validate: false` per-call to skip.
 - Unknown event names are ignored unless you pass `errorUnknownType: true`, which forwards an error to the handler.
+- Connection/open/reconnect/read errors are ignored unless you pass `errorConnect: true`, which forwards an error to the handler.
+- Forwarded connection errors use `new Error('error on open connection', { cause })`; non-OK connection responses are wrapped with `HTTPError` in `cause`.
 - The handler is error-first: it receives either `[err, null]` or `[null, { type, data }]` (the latter allows type narrowing).
 - Reconnect delay follows the SSE spec’s `retry:` field (or the client default of `1000ms` if none is sent).
 - When the stream sends an `id:` field, WireTyped stores it and sends it back as the `Last-Event-ID` header on reconnect (SSE spec).

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -241,6 +241,19 @@ if (err) return err;
 close();
 ```
 
+SSE options:
+```ts
+{
+  validate?: boolean;
+  timeout?: number | false;
+  headers?: HeadersInit;
+  credentials?: RequestCredentials;
+  signal?: AbortSignal;
+  errorUnknownType?: boolean; // forward unknown event names to handler
+  errorConnect?: boolean; // forward open/reconnect/read errors to handler
+}
+```
+
 #### SSE parsing behavior (src/core/client.ts)
 - Each SSE block is parsed by line:
   - event: sets event name (defaults to message)
@@ -250,6 +263,10 @@ close();
 - Unknown event names:
   - ignored by default
   - if errorUnknownType true, handler receives an error
+- Connection/open/reconnect/read errors:
+  - ignored by default
+  - if errorConnect true, handler receives `Error('error on open connection', { cause })`
+  - non-OK connection responses use HTTPError as `cause` (inspect with getHttpError(err))
 - validate false skips schema validation for event payloads
 - Reconnect behavior:
   - default delay 1000ms

--- a/e2e/endpoints.mjs
+++ b/e2e/endpoints.mjs
@@ -105,7 +105,7 @@ export const endpoints = {
   '/sse': {
     sse: {
       $search: z.object({
-        error: z.enum(['never', 'sometimes']),
+        error: z.enum(['never', 'sometimes', 'reset-once', '502-after-first']),
       }),
       events: {
         message: z.object({ i: z.number() }),

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@kasperrt/wiretyped",
-  "version": "0.3.4",
+  "version": "0.3.5-alpha.1",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiretyped",
-  "version": "0.3.4",
+  "version": "0.3.5-alpha.1",
   "description": "Universal fetch-based HTTP client with robust error handling, retries, caching, SSE, and Standard Schema validation.",
   "type": "module",
   "keywords": [

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -3179,7 +3179,7 @@ describe('RequestClient', () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe('error on open connection');
       expect((error as Error).cause).toBeInstanceOf(Error);
-      expect(((error as Error).cause as Error).message).toBe('error no response from fetch provider');
+      expect(((error as Error).cause as Error).message).toBe('error on SSE from fetch');
       expect((((error as Error).cause as Error).cause as Error).message).toBe('fetch failed');
       expect(data).toBeNull();
 
@@ -3231,9 +3231,7 @@ describe('RequestClient', () => {
       const [error, data] = handler.mock.calls[0][0];
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe('error on open connection');
-      expect(((error as Error).cause as Error).message).toBe(
-        'error missing readable response body while opening SSE stream',
-      );
+      expect(((error as Error).cause as Error).message).toBe('error in SSE stream');
       expect(data).toBeNull();
 
       close?.();
@@ -3266,7 +3264,8 @@ describe('RequestClient', () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe('error on open connection');
       expect((error as Error).cause).toBeInstanceOf(Error);
-      expect(((error as Error).cause as Error).message).toBe('bad');
+      expect(((error as Error).cause as Error).message).toBe('error from sse get');
+      expect((((error as Error).cause as Error).cause as Error).message).toBe('bad');
       expect(data).toBeNull();
 
       close?.();

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -2999,6 +2999,45 @@ describe('RequestClient', () => {
       expect(handler).not.toHaveBeenCalled();
     });
 
+    test('forwards reader read error when errorConnect=true', async () => {
+      const handler = vi.fn();
+      const readerError = new Error('boom');
+      vi.spyOn(MOCK_FETCH_PROVIDER.prototype, 'get').mockImplementation(() =>
+        asyncOk({
+          ok: true,
+          status: 200,
+          headers: { get: () => 'text/event-stream' },
+          body: {
+            getReader: () => ({
+              read: vi.fn().mockImplementation(() => Promise.reject(readerError)),
+            }),
+          },
+        } as unknown as Response),
+      );
+
+      const client = new RequestClient({
+        fetchProvider: MOCK_FETCH_PROVIDER,
+        baseUrl: 'https://api.example.com/base',
+        hostname: 'https://api.example.com',
+        fetchOpts: DEFAULT_REQUEST_OPTS,
+        endpoints: mockSseEndpoints,
+        validation: true,
+      });
+
+      const [err, close] = await client.sse('/api/stream', null, handler, { errorConnect: true });
+      expect(err).toBeNull();
+      expect(close).toBeTypeOf('function');
+
+      await flushPromises();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const [error, data] = handler.mock.calls[0][0];
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('error on open connection');
+      expect((error as Error).cause).toBe(readerError);
+      expect(data).toBeNull();
+    });
+
     test('breaks response errored', async () => {
       const handler = vi.fn();
       const readerError = new Error('boom');
@@ -3028,6 +3067,44 @@ describe('RequestClient', () => {
       expect(err).toBeNull();
       expect(close).toBeTypeOf('function');
       expect(handler).not.toHaveBeenCalled();
+    });
+
+    test('forwards non-ok response as HTTPError when errorConnect=true', async () => {
+      const handler = vi.fn();
+      const getSpy = vi.spyOn(MOCK_FETCH_PROVIDER.prototype, 'get').mockImplementation(() =>
+        asyncOk({
+          ok: false,
+          status: 502,
+          headers: { get: () => 'text/event-stream' },
+          body: null,
+        } as unknown as Response),
+      );
+
+      const client = new RequestClient({
+        fetchProvider: MOCK_FETCH_PROVIDER,
+        baseUrl: 'https://api.example.com/base',
+        hostname: 'https://api.example.com',
+        fetchOpts: DEFAULT_REQUEST_OPTS,
+        endpoints: mockSseEndpoints,
+        validation: true,
+      });
+
+      const [err, close] = await client.sse('/api/stream', null, handler, { errorConnect: true });
+      expect(err).toBeNull();
+      expect(close).toBeTypeOf('function');
+
+      await flushPromises();
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledTimes(1);
+      const [error, data] = handler.mock.calls[0][0];
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('error on open connection');
+      expect(isHttpError((error as Error).cause)).toBe(true);
+      expect(((error as Error).cause as { response: Response }).response.status).toBe(502);
+      expect(data).toBeNull();
+
+      close?.();
     });
 
     test('returns early when merged signal already aborted', async () => {
@@ -3075,6 +3152,40 @@ describe('RequestClient', () => {
       expect(getSpy).toHaveBeenCalledTimes(1);
     });
 
+    test('forwards connection errors to handler when fetch throws and errorConnect is true', async () => {
+      const handler = vi.fn();
+      const getSpy = vi.spyOn(MOCK_FETCH_PROVIDER.prototype, 'get').mockImplementation(() => {
+        throw new Error('fetch failed');
+      });
+
+      const client = new RequestClient({
+        fetchProvider: MOCK_FETCH_PROVIDER,
+        baseUrl: 'https://api.example.com/base',
+        hostname: 'https://api.example.com',
+        fetchOpts: DEFAULT_REQUEST_OPTS,
+        endpoints: mockSseEndpoints,
+        validation: true,
+      });
+
+      const [errThrown, close] = await client.sse('/api/stream', null, handler, { errorConnect: true });
+      expect(errThrown).toBeNull();
+      expect(close).toBeTypeOf('function');
+
+      await flushPromises();
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledTimes(1);
+      const [error, data] = handler.mock.calls[0][0];
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('error on open connection');
+      expect((error as Error).cause).toBeInstanceOf(Error);
+      expect(((error as Error).cause as Error).message).toBe('error no response from fetch provider');
+      expect((((error as Error).cause as Error).cause as Error).message).toBe('fetch failed');
+      expect(data).toBeNull();
+
+      close?.();
+    });
+
     test('returns when provider resolves with error tuple', async () => {
       const handler = vi.fn();
       const getSpy = vi
@@ -3094,6 +3205,71 @@ describe('RequestClient', () => {
       expect(err).toBeNull();
       expect(getSpy).toHaveBeenCalledTimes(1);
       expect(handler).not.toHaveBeenCalled();
+    });
+
+    test('forwards missing readable body error when provider tuple has no response and errorConnect is true', async () => {
+      const handler = vi.fn();
+      const getSpy = vi.spyOn(MOCK_FETCH_PROVIDER.prototype, 'get').mockImplementation(() => asyncOk(undefined));
+
+      const client = new RequestClient({
+        fetchProvider: MOCK_FETCH_PROVIDER,
+        baseUrl: 'https://api.example.com/base',
+        hostname: 'https://api.example.com',
+        fetchOpts: DEFAULT_REQUEST_OPTS,
+        endpoints: mockSseEndpoints,
+        validation: true,
+      });
+
+      const [err, close] = await client.sse('/api/stream', null, handler, { errorConnect: true });
+      expect(err).toBeNull();
+      expect(close).toBeTypeOf('function');
+
+      await flushPromises();
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledTimes(1);
+      const [error, data] = handler.mock.calls[0][0];
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('error on open connection');
+      expect(((error as Error).cause as Error).message).toBe(
+        'error missing readable response body while opening SSE stream',
+      );
+      expect(data).toBeNull();
+
+      close?.();
+    });
+
+    test('forwards connection errors to handler when provider resolves with error tuple and errorConnect is true', async () => {
+      const handler = vi.fn();
+      const getSpy = vi
+        .spyOn(MOCK_FETCH_PROVIDER.prototype, 'get')
+        .mockImplementation(() => asyncErr(new Error('bad')));
+
+      const client = new RequestClient({
+        fetchProvider: MOCK_FETCH_PROVIDER,
+        baseUrl: 'https://api.example.com/base',
+        hostname: 'https://api.example.com',
+        fetchOpts: DEFAULT_REQUEST_OPTS,
+        endpoints: mockSseEndpoints,
+        validation: true,
+      });
+
+      const [err, close] = await client.sse('/api/stream', null, handler, { errorConnect: true });
+      expect(err).toBeNull();
+      expect(close).toBeTypeOf('function');
+
+      await flushPromises();
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledTimes(1);
+      const [error, data] = handler.mock.calls[0][0];
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('error on open connection');
+      expect((error as Error).cause).toBeInstanceOf(Error);
+      expect(((error as Error).cause as Error).message).toBe('bad');
+      expect(data).toBeNull();
+
+      close?.();
     });
 
     test('returns early when merged signal is aborted before fetch', async () => {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -406,6 +406,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       headers,
       signal,
       errorUnknownType,
+      errorConnect,
       credentials = this.#credentials,
       ...options
     } = opts;
@@ -501,6 +502,14 @@ export class RequestClient<Schema extends RequestDefinitions> {
       handler([null, { type: eventName, data: validated }]);
     };
 
+    const emitConnectionError = (cause: unknown) => {
+      if (!errorConnect) {
+        return;
+      }
+
+      handler([new Error('error on open connection', { cause }), null]);
+    };
+
     const open = async () => {
       const timeoutSignal = createTimeoutSignal(timeout);
       const mergedSignal = mergeSignals([signal, controller.signal, timeoutSignal, this.#abortController.signal]);
@@ -524,11 +533,23 @@ export class RequestClient<Schema extends RequestDefinitions> {
       );
 
       if (errWrapped || !wrapped) {
+        emitConnectionError(new Error('error no response from fetch provider', { cause: errWrapped }));
         return;
       }
 
       const [errResponse, response] = wrapped;
       if (errResponse || !response?.ok || typeof response.body?.getReader !== 'function') {
+        if (errResponse) {
+          emitConnectionError(errResponse);
+          return;
+        }
+
+        if (response && !response.ok) {
+          emitConnectionError(new HTTPError(response, 'error non-ok response while opening SSE stream'));
+          return;
+        }
+
+        emitConnectionError(new Error('error missing readable response body while opening SSE stream'));
         return;
       }
 
@@ -538,6 +559,7 @@ export class RequestClient<Schema extends RequestDefinitions> {
       while (true) {
         const [errRead, chunk] = await safeWrapAsync(() => reader.read());
         if (errRead) {
+          emitConnectionError(errRead);
           break;
         }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -171,7 +171,7 @@ export type SSEHandlerCallback<T> = { handler(value: SafeWrap<Error, T>): void }
 
 /** SSE Options */
 export type SSEOptions = Omit<FetchOptions, 'body' | 'method' | 'keepalive'> &
-  Pick<RequestOptions, 'timeout' | 'validate'> & { errorUnknownType?: boolean };
+  Pick<RequestOptions, 'timeout' | 'validate'> & { errorUnknownType?: boolean; errorConnect?: boolean };
 
 /**
  * Typed parameters for get function call parameters


### PR DESCRIPTION
Add option to propagate connection errors by opt-in when instantiating SSE connection, into handler. Useful for showing/viewing errors when SSE connection is in a broken state and working on reconnecting
